### PR TITLE
Absolute path to runuser in the init script

### DIFF
--- a/templates/default/redis.init.erb
+++ b/templates/default/redis.init.erb
@@ -18,7 +18,7 @@ REDISPORT=<%= @port %>
 <% when 'ubuntu','debian','fedora' %>
 EXEC="sudo -u <%= @user %> <%= File.join(@bin_path, 'redis-server') %> <%= @configdir %>/${REDISNAME}.conf"
 <% else %> 
-EXEC="runuser <%= @user %> -c \"<%= File.join(@bin_path, 'redis-server') %> <%= @configdir %>/${REDISNAME}.conf\""
+EXEC="/sbin/runuser <%= @user %> -c \"<%= File.join(@bin_path, 'redis-server') %> <%= @configdir %>/${REDISNAME}.conf\""
 <% end %>
 CLIEXEC=<%= File.join(@bin_path, 'redis-cli') %>
 


### PR DESCRIPTION
This allows the redis service to be controlled using `sudo /etc/init.d/redis` on CentOS 5 and shouldn't break the non-Ubuntu, -Debian, and -Fedora platforms that will be running this command.
