### PR TITLE
Fix the hash ziplist version check

### DIFF
--- a/templates/default/redis.conf.erb
+++ b/templates/default/redis.conf.erb
@@ -476,8 +476,7 @@ vm-max-threads 4
 # small number of entries, and the biggest entry does not exceed a given
 # threshold. These thresholds can be configured using the following directives.
 
-<% #Once the first official 2.6 release is out, it would make sense to remove the extraneous :minor 5 comparison %>
-<% if @version[:major].to_i == 2 && (@version[:minor].to_i == 6 || @version[:minor].to_i == 5)  %> 
+<% if @version[:major].to_i == 2 && (@version[:minor].to_i >= 6)  %> 
   ######## Redis 2.6 ########
   hash-max-ziplist-entries 512
   hash-max-ziplist-value 64


### PR DESCRIPTION
This is a PR to correct the version-minor check for the ziplist config attrs.  I think something similar is already in 2.0.0_wip, but this is useful for those of us using the 1.7.x line.  We use your cookbook to run redis 2.8.8 and needed this fix.