### PR TITLE
Change each_line to each

### DIFF
--- a/templates/default/redis.conf.erb
+++ b/templates/default/redis.conf.erb
@@ -122,7 +122,7 @@ databases <%=@databases%>
     save 300 10
     save 60 10000
   <% else %>
-    <% @save.each_line do |save_option| %>
+    <% @save.each do |save_option| %>
       <%= "save #{save_option}" %>
     <% end %>
   <% end %>


### PR DESCRIPTION
The redis.conf.erb template used a deprecated each_line call. This
change replaces that with each.