### PR TITLE
minor markdown formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,11 +241,11 @@ Configuration options, each option corresponds to the same-named configuration o
 * `redisio['base_name']` - the base name of the redis package to be downloaded (the part before the version), default is 'redis-'
 * `redisio['artifact_type']` - the file extension of the package.  currently only .tar.gz and .tgz are supported, default is 'tar.gz'
 * `redisio['version']` - the version number of redis to install (also appended to the `base_name` for downloading), default is '2.8.17'
-* `redisio['safe_install'] - prevents redis from installing itself if another version of redis is installed, default is true
-* `redisio['base_piddir'] - This is the directory that redis pidfile directories and pidfiles will be placed in.  Since redis can run as non root, it needs to have proper
+* `redisio['safe_install']` - prevents redis from installing itself if another version of redis is installed, default is true
+* `redisio['base_piddir']` - This is the directory that redis pidfile directories and pidfiles will be placed in.  Since redis can run as non root, it needs to have proper
                            permissions to the directory to create its pid.  Since each instance can run as a different user, these directories will all be nested inside this base one.
-* `redisio['bypass_setup'] - This attribute allows users to prevent the default recipe from calling the install and configure recipes.
-* `redisio['job_control'] - This deteremines what job control type will be used.  Currently supports 'initd' or 'upstart' options.  Defaults to 'initd'.
+* `redisio['bypass_setup']` - This attribute allows users to prevent the default recipe from calling the install and configure recipes.
+* `redisio['job_control']` - This deteremines what job control type will be used.  Currently supports 'initd' or 'upstart' options.  Defaults to 'initd'.
 
 Default settings is a hash of default settings to be applied to to ALL instances.  These can be overridden for each individual server in the servers attribute.  If you are going to set logfile to a specific file, make sure to set syslog-enabled to no.
 


### PR DESCRIPTION
A few of the redisio[] attributes were missing backticks for the code spans