### PR TITLE
Allow redis config template to be sourced from another cookbook

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,6 +31,10 @@ else
   homedir = '/redis'
 end
 
+# Overwite template
+default['redisio']['template_cookbook'] = "redisio"
+default['redisio']['template_source'] = "redis.conf.erb"
+
 # Install related attributes
 default['redisio']['safe_install'] = true
 default['redisio']['bypass_setup'] = false

--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -170,8 +170,8 @@ def configure
       
       #Lay down the configuration files for the current instance
       template "#{current['configdir']}/#{server_name}.conf" do
-        source 'redis.conf.erb'
-        cookbook 'redisio'
+	source node['redisio']['template_source']
+        cookbook node['redisio']['template_cookbook']
         owner current['user']
         group current['group']
         mode '0644'


### PR DESCRIPTION
I needed to change the template, and easiest way to do this was to change the cookbook/name. It wasn't configurable.
