### PR TITLE
feat: adding package installation support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,6 +11,9 @@ platforms:
   - name: ubuntu-12.04
   - name: debian-6.0.8
   - name: centos-6.4
+    run_list:
+      - recipe[yum-epel::default]
+      - recipe[yum-remi::default]
   - name: fedora-20
 
 suites:
@@ -25,6 +28,23 @@ suites:
                 port: 6379,
               }
             ]
+  - name: redis-package
+    run_list:
+      - recipe[redisio::default]
+      - recipe[redisio::enable]
+    attributes:
+     redisio:
+        servers: [
+              {
+                port: 6379,
+              }
+            ]
+        package_install: true
+        version: 
+    excludes:
+      - ubuntu-12.04
+      - debian-6.0.8
+      - fedora-20
   - name: sentinel
     run_list:
       - recipe[redisio::default]

--- a/Berksfile
+++ b/Berksfile
@@ -4,3 +4,5 @@ metadata
 
 cookbook "ulimit", ">= 0.1.2"
 cookbook "build-essential"
+cookbook "yum-epel"
+cookbook "yum-remi"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Installs and configures Redis server instances
 Requirements
 ============
 
-This cookbook builds redis from source, so it should work on any architecture for the supported distributions.  Init scripts are installed into /etc/init.d/
+This cookbook builds redis from source or install it from packages, so it should work on any architecture for the supported distributions.  Init scripts are installed into /etc/init.d/
 
 It depends on the ulimit cookbook: https://github.com/bmhatfield/chef-ulimit and the build-essentials cookbook: https://github.com/opscode-cookbooks/build-essential
 
@@ -43,7 +43,7 @@ Usage
 
 The redisio cookbook contains LWRP for installing, configuring and managing redis and redis_sentinel.
 
-The install recipe will only build, compile and install redis. The configure recipe will configure redis and setup service resources.  These resources will be named for the port of the redis server, unless a "name" attribute was specified.  Example names would be: service["redis6379"] or service["redismaster"] if the name attribute was "master".
+The install recipe can build, compile and install redis from sources or install from packages. The configure recipe will configure redis and setup service resources.  These resources will be named for the port of the redis server, unless a "name" attribute was specified.  Example names would be: service["redis6379"] or service["redismaster"] if the name attribute was "master".
 
 The most common use case for the redisio cookbook is to use the default recipe, followed by the enable recipe.  
 
@@ -83,6 +83,21 @@ run_list *%w[
 ]
 
 default_attributes({})
+```
+#### Install redis with packages and setup an instance with default settings on default port, and start the service through a role file #
+
+```ruby
+run_list *%w[
+  recipe[redisio]
+  recipe[redisio::enable]
+]
+
+default_attributes({
+  'redisio' => {
+    package_install: true
+    version:
+  }
+})
 ```
 
 #### Install redis, give the instance a name, and use a unix socket #

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,14 +33,24 @@ end
 
 # Install related attributes
 default['redisio']['safe_install'] = true
+default['redisio']['package_install'] = false
+default['redisio']['package_name'] = 'redis'
 default['redisio']['bypass_setup'] = false
 
 # Tarball and download related defaults
 default['redisio']['mirror'] = "http://download.redis.io/releases/"
 default['redisio']['base_name'] = 'redis-'
 default['redisio']['artifact_type'] = 'tar.gz'
-default['redisio']['version'] = '2.8.17'
 default['redisio']['base_piddir'] = '/var/run/redis'
+
+# Version
+if node['redisio']['package_install']
+  # latest version (only for package install)
+  default['redisio']['version'] = nil
+else
+  # force version for tarball
+  default['redisio']['version'] = '2.8.17'
+end
 
 # Custom installation directory
 default['redisio']['install_dir'] = nil
@@ -117,3 +127,9 @@ default['redisio']['default_settings'] = {
 # The default for this is set inside of the "install" recipe. This is due to the way deep merge handles arrays
 default['redisio']['servers'] = nil
 
+# Define binary path
+if node['redisio']['package_install']
+  default['redisio']['bin_path'] = '/usr/bin'
+else
+  default['redisio']['bin_path'] = '/usr/local/bin'
+end

--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -25,7 +25,14 @@ end
 
 def configure
   base_piddir = new_resource.base_piddir
-  version_hash = RedisioHelper.version_to_hash(new_resource.version)
+
+  if not new_resource.version
+    redis_output = %x[#{node['redisio']['bin_path']}/redis-server -v]
+    current_version = redis_output.gsub(/.*v=((\d+\.){2}\d+).*/, '\1')
+  else
+    current_version = new_resource.version
+  end
+  version_hash = RedisioHelper.version_to_hash(current_version)
 
   #Setup a configuration file and init script for each configuration provided
   new_resource.servers.each do |current_instance|
@@ -230,7 +237,8 @@ def configure
         })
       end
       #Setup init.d file
-      bin_path = "/usr/local/bin"
+
+      bin_path = node['redisio']['bin_path']
       bin_path = ::File.join(node['redisio']['install_dir'], 'bin') if node['redisio']['install_dir']
       template "/etc/init.d/redis#{server_name}" do
         source 'redis.init.erb'

--- a/providers/sentinel.rb
+++ b/providers/sentinel.rb
@@ -122,7 +122,7 @@ def configure
         })
       end
       #Setup init.d file
-      bin_path = "/usr/local/bin"
+      bin_path = node['redisio']['bin_path']
       bin_path = ::File.join(node['redisio']['install_dir'], 'bin') if node['redisio']['install_dir']
       template "/etc/init.d/redis_#{sentinel_name}" do
         source 'sentinel.init.erb'

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -28,7 +28,7 @@ if redis_instances.nil?
 end
 
 redisio_configure "redis-servers" do
-  version redis['version']
+  version redis['version'] if redis['version']
   default_settings redis['default_settings']
   servers redis_instances
   base_piddir redis['base_piddir']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -29,8 +29,10 @@ if platform?("debian","ubuntu")
   end
 end
 
-include_recipe "redisio::_install_prereqs"
-include_recipe "build-essential::default"
+unless node['redisio']['package_install']
+  include_recipe "redisio::_install_prereqs"
+  include_recipe "build-essential::default"
+end
 
 unless node['redisio']['bypass_setup']
   include_recipe "redisio::install"

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -16,16 +16,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-include_recipe 'redisio::_install_prereqs'
-include_recipe 'build-essential::default'
-include_recipe 'ulimit::default'
+if node['redisio']['package_install']
+  package "redisio_package_name" do
+    package_name node['redisio']['package_name']
+    action :install
+  end
+else
+  include_recipe 'redisio::_install_prereqs'
+  include_recipe 'build-essential::default'
 
-redis = node['redisio']
-location = "#{redis['mirror']}/#{redis['base_name']}#{redis['version']}.#{redis['artifact_type']}"
+  redis = node['redisio']
+  location = "#{redis['mirror']}/#{redis['base_name']}#{redis['version']}.#{redis['artifact_type']}"
 
-redisio_install "redis-installation" do
-  version redis['version']
-  download_url location
-  safe_install redis['safe_install']
-  install_dir redis['install_dir']
+  redisio_install "redis-installation" do
+    version redis['version']
+    download_url location
+    safe_install redis['safe_install']
+    install_dir redis['install_dir']
+  end
 end
+
+include_recipe 'ulimit::default'


### PR DESCRIPTION
Hi,

First, thanks for your cookbook.
In your cookbook, the only way to install Redis is through tarballs. For production usage, it's better to not install all dependencies, recompile on production server, etc...

That's why I added the packaging support. It requires additional repositories to get the latest version (as described in the .kitchen.yml and Berksfile) but is not directly managed by the cookbook as it's not its role.

I kept the way you managed multi tenancies through init/upstart scripts.

Can you please merge this PR.

Thanks in advance
