### PR TITLE
Use grep to find service, serverspec uses systemd

### DIFF
--- a/test/integration/default/serverspec/redisio_spec.rb
+++ b/test/integration/default/serverspec/redisio_spec.rb
@@ -6,10 +6,12 @@ describe 'Redis' do
     expect(service 'redis6379').to be_enabled
   end
 
-  it 'starts the redis service' do
-    # be_running uses ps aux, the service runs as redis-server *:6379 not as the service name redis6379
-    # Ensure a redis process is running on port 6379. .* regex to match everything between redis and port
-    expect(service 'redis6379').to be_running
+  context 'starts the redis service' do
+    # We use grep and commands here, since serverspec only checks systemd on fedora 20
+    # instead of also being able to check sysv style init systems.
+    describe command('ps aux | grep -v grep | grep \'redis-server\' | grep \'*:6379\'') do
+      its(:exit_status) { should eq(0) }
+    end
   end
 
   it 'is listening on port 6379' do

--- a/test/integration/sentinel/serverspec/sentinel_spec.rb
+++ b/test/integration/sentinel/serverspec/sentinel_spec.rb
@@ -6,8 +6,10 @@ describe 'Redis-Sentinel' do
     expect(service 'redis_sentinel_mycluster').to be_enabled
   end
 
-  it 'starts the redis-setinel service' do
-    expect(service 'redis_sentinel_mycluster').to be_running
+  context 'starts the redis-setinel service' do
+    describe command('ps aux | grep -v grep | grep \'redis-server\' | grep \'*:26379\'') do
+      its(:exit_status) { should eq(0) }
+    end
   end
 
   it 'is listening on port 26379' do


### PR DESCRIPTION
Serverspec assumes systemd, and chef 12 uses sys-v. So use grep to find the service, for our testing. Fixes #181.