### PR TITLE
Allow instance 'save' to be string or array

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -23,24 +23,21 @@ suites:
       - recipe[redisio::enable]
     attributes:
      redisio:
-        servers: [
-              {
-                port: 6379,
-              }
-            ]
+        servers:
+          - port: 6379
+          - port: 16379
+            name: 'savetest'
+            save: "a\nb\nc"
   - name: redis-package
     run_list:
       - recipe[redisio::default]
       - recipe[redisio::enable]
     attributes:
      redisio:
-        servers: [
-              {
-                port: 6379,
-              }
-            ]
+        servers:
+          - port: 6379,
         package_install: true
-        version: 
+        version:
     excludes:
       - ubuntu-12.04
       - debian-6.0.8
@@ -53,8 +50,5 @@ suites:
       - recipe[redisio::sentinel_enable]
     attributes:
      redisio:
-        servers: [
-              {
-                port: 6379,
-              }
-            ]
+        servers:
+          - port: 6379

--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -175,7 +175,14 @@ def configure
         filehandle_limit descriptors
         only_if { current['ulimit'] }
       end
-      
+
+      computed_save = current['save']
+      if current['save'] && current['save'].respond_to?(:each_line)
+        computed_save = current['save'].each_line
+        Chef::Log.warn("#{server_name}: given a save argument as a string, instead of an array.")
+        Chef::Log.warn("#{server_name}: This will be deprecated in future versions of the redisio cookbook.")
+      end
+
       #Lay down the configuration files for the current instance
       template "#{current['configdir']}/#{server_name}.conf" do
         source 'redis.conf.erb'
@@ -202,7 +209,7 @@ def configure
           :logfile                    => current['logfile'],
           :syslogenabled              => current['syslogenabled'],
           :syslogfacility             => current['syslogfacility'],
-          :save                       => current['save'],
+          :save                       => computed_save,
           :stopwritesonbgsaveerror    => current['stopwritesonbgsaveerror'],
           :slaveof                    => current['slaveof'],
           :masterauth                 => current['masterauth'],

--- a/templates/default/redis.conf.erb
+++ b/templates/default/redis.conf.erb
@@ -122,7 +122,7 @@ databases <%=@databases%>
     save 300 10
     save 60 10000
   <% else %>
-    <% @save.each_line do |save_option| %>
+    <% @save.each do |save_option| %>
       <%= "save #{save_option}" %>
     <% end %>
   <% end %>

--- a/test/integration/default/serverspec/redisio_spec.rb
+++ b/test/integration/default/serverspec/redisio_spec.rb
@@ -3,3 +3,12 @@ require 'spec_helper'
 describe 'Redis' do
   it_behaves_like 'redis on port', 6379
 end
+
+describe file('/etc/redis/savetest.conf') do
+  it { should be_file }
+
+  ['save a', 'save b', 'save c'].each do |m|
+    its(:content) { should match(m) }
+  end
+
+end


### PR DESCRIPTION
Fixes #166.

- Allow 'save' to be anything that responds to `.each`. If it responds to `.each_line`, we unwrap that.
- Add a test to be sure backwards compatible 'string' works for the save attribute.
- Make .kitchen.yml redis instances be easier YAML syntax for array-of-hashes