### PR TITLE
Add support for Ubuntu via package install

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,6 +9,7 @@ provisioner:
 
 platforms:
   - name: ubuntu-12.04
+  - name: ubuntu-14.04
   - name: debian-6.0.8
   - name: centos-6.6
     run_list:
@@ -40,7 +41,7 @@ suites:
               }
             ]
         package_install: true
-        version: 
+        version:
     excludes:
       - ubuntu-12.04
       - debian-6.0.8

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,21 +20,25 @@ case node['platform']
 when 'ubuntu','debian'
   shell = '/bin/false'
   homedir = '/var/lib/redis'
+  package_name = 'redis-server'
 when 'centos','redhat','scientific','amazon','suse'
   shell = '/bin/sh'
   homedir = '/var/lib/redis'
+  package_name = 'redis'
 when 'fedora'
   shell = '/bin/sh'
   homedir = '/home' #this is necessary because selinux by default prevents the homedir from being managed in /var/lib/
+  package_name = 'redis'
 else
   shell = '/bin/sh'
   homedir = '/redis'
+  package_name = 'redis'
 end
 
 # Install related attributes
 default['redisio']['safe_install'] = true
 default['redisio']['package_install'] = false
-default['redisio']['package_name'] = 'redis'
+default['redisio']['package_name'] = package_name
 default['redisio']['bypass_setup'] = false
 
 # Tarball and download related defaults


### PR DESCRIPTION
RE: #177.

- Add package support for ubuntu family, with slightly different package name
- Add platform ubuntu 14.04 to our test suites, allow package method to be tested on 14.04