### PR TITLE
Configuration options for redis cluster are not correctly propogated

### DIFF
--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -238,9 +238,9 @@ def configure
           :clientoutputbufferlimit    => current['clientoutputbufferlimit'],
           :hz                         => current['hz'],
           :aofrewriteincrementalfsync => current['aofrewriteincrementalfsync'],
-          :clusterenabled             => current['clusterenabled'],
-          :clusterconfigfile          => current['clusterconfigfile'],
-          :clusternodetimeout         => current['clusternodetimeout'],
+          :clusterenabled             => current['cluster-enabled'],
+          :clusterconfigfile          => current['cluster-config-file'],
+          :clusternodetimeout         => current['cluster-node-timeout'],
           :includes                   => current['includes']
         })
       end


### PR DESCRIPTION
According to the documentation the Redis cluster params are defined:
'cluster-enabled'            => 'no',
'cluster-config-file'        => nil, # Defaults to redis instance name inside of template if cluster is enabled.
'cluster-node-timeout'       => 5,
However:
In providers/configure.rb they were referred to as: 
clusterenabled, clusterconfigfile, clusternodetimeout
as a result these params were ignored and didn't make into redis.conf file
