### PR TITLE
Attribute and template tweaks for client-reconfig-script functionality.

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,8 @@ The sentinel recipe's use their own attribute file.
 'logfile'                 => nil,
 'syslogenabled'           => 'yes',
 'syslogfacility'          => 'local0',
-'quorum_count'            => 2
+'quorum_count'            => 2,
+'client-reconfig-script'  => nil
 ```
 
 * `redisio['redisio']['sentinel']['manage_config']` - Should the cookbook manage the redis and redis sentinel config files.  This is best set to false when using redis_sentinel as it will write state into both configuration files.

--- a/attributes/redis_sentinel.rb
+++ b/attributes/redis_sentinel.rb
@@ -29,7 +29,8 @@ default['redisio']['sentinel_defaults'] = {
   'logfile'                 => nil,
   'syslogenabled'           => 'yes',
   'syslogfacility'          => 'local0',
-  'quorum_count'            => 2
+  'quorum_count'            => 2,
+  'client-reconfig-script'  => nil
 }
 
 # Manage Sentinel Config File

--- a/providers/sentinel.rb
+++ b/providers/sentinel.rb
@@ -118,7 +118,8 @@ def configure
           :logfile                => current['logfile'],
           :syslogenabled          => current['syslogenabled'],
           :syslogfacility         => current['syslogfacility'],
-          :quorum_count           => current['quorum_count']
+          :quorum_count           => current['quorum_count'],
+          :clientreconfigscript   => current['client-reconfig-script']
         })
       end
       #Setup init.d file

--- a/templates/default/sentinel.conf.erb
+++ b/templates/default/sentinel.conf.erb
@@ -154,3 +154,4 @@ sentinel failover-timeout <%=@name%> <%=@failovertimeout%>
 # Example:
 #
 # sentinel client-reconfig-script mymaster /var/redis/reconfig.sh
+<%= "sentinel client-reconfig-script #{@name} #{@clientreconfigscript}" unless @clientreconfigscript.nil? %>


### PR DESCRIPTION
We use a floating IP to provide redis client access to a sentinel managed master without the need to have the client code be sentinel aware. This PR adds hooks for the redisio cookbook to manage those hooks in sentinel.conf.

Here's a sample script directly cribbed from http://blog.waja.info/2014/09/25/redis-ha-with-redis-sentinel-and-vip/ and augmented with some helpful comments:

```
#!/bin/bash
_DEBUG="off"
DEBUGFILE=/tmp/sentinel_failover.log
VIP='<%= node[:redis_vip] %>'
MASTERIP=${6}
MASK='24'
IFACE='eth0'
MYIP=$(ip -4 -o addr show dev ${IFACE}| grep -v secondary| awk '{split($4,a,"/");print a[1]}')

DEBUG () {
        if [ "$_DEBUG" = "on" ]; then
                $@ 2>&1 | tee -a ${DEBUGFILE}
        fi
}

set -e
DEBUG echo '--------------------------------------------------------------------------------'
DEBUG date
DEBUG echo "Running as $(whoami)"
DEBUG echo "Old Master: ${4}"
DEBUG echo "New Master: ${MASTERIP}"
DEBUG echo "My IP: ${MYIP}"
DEBUG echo "Arguments passed: $@"
DEBUG echo '--'

if [ ${MASTERIP} = ${MYIP} ]; then
  DEBUG echo "I am the new master!"
        if [ $(ip addr show ${IFACE} | grep ${VIP} | wc -l) = 0 ]; then
                DEBUG echo "I'm going to assume the VIP, but let's sleep for a couple to allow the old master to release it..."
                /bin/sleep 2
                DEBUG echo "Running /usr/bin/sudo /sbin/ip addr add ${VIP}/${MASK} dev ${IFACE}"
                /usr/bin/sudo /sbin/ip addr add ${VIP}/${MASK} dev ${IFACE}
                DEBUG echo "exit code was $?"
                DEBUG echo "Running /usr/bin/sudo /usr/sbin/arping -q -c 3 -A ${VIP} -I ${IFACE}"
                /usr/bin/sudo /usr/sbin/arping -q -c 3 -A ${VIP} -I ${IFACE}
                DEBUG echo "exit code was $?"
        fi
        exit 0
else
  DEBUG echo "I'm not the new master. :-("
        if [ $(ip addr show ${IFACE} | grep ${VIP} | wc -l) != 0 ]; then
                DEBUG echo "I was the old master, going to give up the VIP..."
                DEBUG echo "Running /usr/bin/sudo /sbin/ip addr del ${VIP}/${MASK} dev ${IFACE}"
                /usr/bin/sudo /sbin/ip addr del ${VIP}/${MASK} dev ${IFACE}
                DEBUG echo "exit code was $?"
        fi
        exit 0
fi
exit 1
```

This can be specified in a role, along with a "redis_vip" attribute specifying your VIP address file as such:

```
name "redis-master-sentinel"
run_list *%w[
  recipe[redisio]
  recipe[redisio::configure]
  recipe[redisio::enable]
  recipe[redisio::sentinel]
  recipe[redisio::sentinel_enable]
]
default_attributes({
  'redis_vip' => "YOUR.VIP.ADDRESS.HERE",
  'redisio' => {
    'default_settings' => {
      'backuptype' => 'aof',
    },
    'sentinel_defaults' => {
      'client-reconfig-script' => '/var/lib/redis/vip_failover.sh',
      'down-after-milliseconds' => 8000,
      'parallel-syncs' => 2,
    },
    'sentinels' => [ {
      'master_ip' => 'YOUR.INITIAL.SENTINEL.MASTERIP',
      'master_port' => '6379',
      'name' => 'YOUR_ENV',
    } ],
    'sentinel' => {
      'manage_config' => false
    }
  }
})
```

When applied to a node, this role will set up a redis instance on 6379 and a sentinel on 26379, and configuring sentinel to call the script at `/var/lib/redis/vip_failover.sh` during a failover. We use a second role "redis-slave-sentinel" which also includes the "slaveof" attribute for the initial configuration to complete the sentinel cluster setup. _Note: The client-reconfig-script must exist and be executable, or sentinel will not start. Use a template resource to lay down `/var/lib/redis/vip_failover.sh` somewhere earlier in your node's run_list._
