### PR TITLE
Add support for slave-priority in redisio

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -88,6 +88,7 @@ default['redisio']['default_settings'] = {
   'save'                    => nil, # Defaults to ['900 1','300 10','60 10000'] inside of template.  Needed due to lack of hash subtraction
   'stopwritesonbgsaveerror' => 'yes',
   'slaveof'                 => nil,
+  'slavepriority'           => '100',
   'masterauth'              => nil,
   'slaveservestaledata'     => 'yes',
   'replpingslaveperiod'     => '10',

--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -212,6 +212,7 @@ def configure
           :save                       => computed_save,
           :stopwritesonbgsaveerror    => current['stopwritesonbgsaveerror'],
           :slaveof                    => current['slaveof'],
+	  :slavepriority              => current['slavepriority'],
           :masterauth                 => current['masterauth'],
           :slaveservestaledata        => current['slaveservestaledata'],
           :replpingslaveperiod        => current['replpingslaveperiod'],

--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -212,7 +212,7 @@ def configure
           :save                       => computed_save,
           :stopwritesonbgsaveerror    => current['stopwritesonbgsaveerror'],
           :slaveof                    => current['slaveof'],
-	  :slavepriority              => current['slavepriority'],
+          :slavepriority              => current['slavepriority'],
           :masterauth                 => current['masterauth'],
           :slaveservestaledata        => current['slaveservestaledata'],
           :replpingslaveperiod        => current['replpingslaveperiod'],

--- a/templates/default/redis.conf.erb
+++ b/templates/default/redis.conf.erb
@@ -208,6 +208,22 @@ repl-ping-slave-period <%=@replpingslaveperiod%>
 #
 repl-timeout <%=@repltimeout%>
 
+# The slave priority is an integer number published by Redis in the INFO output.
+# It is used by Redis Sentinel in order to select a slave to promote into a
+# master if the master is no longer working correctly.
+#
+# A slave with a low priority number is considered better for promotion, so
+# for instance if there are three slaves with priority 10, 100, 25 Sentinel will
+# pick the one with priority 10, that is the lowest.
+#
+# However a special priority of 0 marks the slave as not able to perform the
+# role of master, so a slave with priority of 0 will never be selected by
+# Redis Sentinel for promotion.
+#
+# By default the priority is 100.
+# slave-priority 100
+<%= "slave-priority #{@slavepriority}" unless @slavepriority.nil? %>
+
 ################################## SECURITY ###################################
 
 # Require clients to issue AUTH <PASSWORD> before processing any other


### PR DESCRIPTION
The attached change should allow setting slave-priority in redis.conf in line with the rest of the cookbook.

Please review and let me know if anything is amiss.

-Jason