### PR TITLE
Fix cluster settings, because they differs at providers/ and attributes/

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -118,9 +118,9 @@ default['redisio']['default_settings'] = {
   ],
   'hz'                         => '10',
   'aofrewriteincrementalfsync' => 'yes',
-  'cluster-enabled'            => 'no',
-  'cluster-config-file'        => nil, # Defaults to redis instance name inside of template if cluster is enabled.
-  'cluster-node-timeout'       => 5,
+  'clusterenabled'            => 'no',
+  'clusterconfigfile'        => nil, # Defaults to redis instance name inside of template if cluster is enabled.
+  'clusternodetimeout'       => 5,
   'includes'                   => nil
 }
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'brian.bianco@gmail.com'
 license          'Apache 2.0'
 description      'Installs/Configures redis'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.3.0'
+version          '2.3.1'
 %w[ debian ubuntu centos redhat fedora scientific suse amazon].each do |os|
   supports os
 end


### PR DESCRIPTION
Fix cluster settings, because they differs at providers/ and attributes/. If setting up `cluster-enabled`, nothing happens, because providers expect to have `clusterenabled`. 