### PR TITLE
Monitor multiple masters with single sentinel

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -52,3 +52,29 @@ suites:
      redisio:
         servers:
           - port: 6379
+  - name: multisentinel
+    run_list:
+      - recipe[redisio::default]
+      - recipe[redisio::enable]
+      - recipe[redisio::sentinel]
+      - recipe[redisio::sentinel_enable]
+    attributes:
+     redisio:
+        servers:
+          - port: 6379
+          - port: 6380
+        sentinels:
+          -
+            name: 'cluster'
+            sentinel_port: 26379
+            masters:
+              -
+                name: 'sentinel6379'
+                master_name: 'master6379'
+                master_ip: '127.0.0.1'
+                master_port: 6379
+              -
+                name: 'sentinel6380'
+                master_name: 'master6380'
+                master_ip: '127.0.0.1'
+                master_port: 6380

--- a/README.md
+++ b/README.md
@@ -359,6 +359,18 @@ The sentinel recipe's use their own attribute file.
 
 * `redisio['redisio']['sentinels']` - Array of sentinels to configure on the node. These settings will override the options in 'sentinel_defaults', if it is left `nil` it will default to `[{'port' => '26379', 'name' => 'mycluster', 'master_ip' => '127.0.0.1', 'master_port' => 6379}]`. If set to `[]` (empty array), no instances will be created.
 
+You may also pass an array of masters to monitor like so:
+```
+[{
+  'sentinel_port' => '26379',
+  'name' => 'mycluster_sentinel',
+  'masters' => [
+    { master_name = 'master6379', master_ip' => '127.0.0.1', 'master_port' => 6379 },
+    { master_name = 'master6380', master_ip' => '127.0.0.1', 'master_port' => 6380 }
+  ]
+
+}]
+```
 
 Resources/Providers
 ===================

--- a/recipes/sentinel.rb
+++ b/recipes/sentinel.rb
@@ -25,7 +25,15 @@ redis = node['redisio']
 
 sentinel_instances = redis['sentinels']
 if sentinel_instances.nil?
-  sentinel_instances = [{'sentinel_port' => '26379', 'name' => 'mycluster', 'master_ip' => '127.0.0.1', 'master_port' => '6379'}]
+  sentinel_instances = [{
+    'sentinel_port' => '26379',
+    'name' => 'mycluster',
+    'masters' => [{
+      'master_name' => 'mycluster_master',
+      'master_ip' => '127.0.0.1',
+      'master_port' => '6379'
+    }]
+    }]
 end
 
 redisio_sentinel "redis-sentinels" do

--- a/templates/default/sentinel.conf.erb
+++ b/templates/default/sentinel.conf.erb
@@ -23,8 +23,10 @@ port <%=@sentinel_port%>
 # Note: master name should not include special characters or spaces.
 # The valid charset is A-z 0-9 and the three characters ".-_".
 # sentinel monitor mymaster 127.0.0.1 6379 2
-sentinel monitor <%=@name%> <%=@masterip%> <%=@masterport%> <%= @quorum_count %>
-
+<% @masters.each do |current| %>
+<% calc_name = current['master_name'].to_s || @name.to_s %>
+sentinel monitor <%=calc_name%> <%=current['master_ip']%> <%=current['master_port']%> <%= current['quorum_count'] %>
+<% end %>
 # sentinel auth-pass <master-name> <password>
 #
 # Set the password to use to authenticate with the master and slaves.
@@ -43,8 +45,10 @@ sentinel monitor <%=@name%> <%=@masterip%> <%=@masterport%> <%= @quorum_count %>
 # Example:
 #
 # sentinel auth-pass mymaster MySUPER--secret-0123passw0rd
-<%= "sentinel auth-pass #{@name} #{@authpass}" unless @authpass.nil? %>
-
+<% @masters.each do |current| %>
+<% calc_name = current['master_name'].to_s || @name.to_s %>
+<%= "sentinel auth-pass #{calc_name} #{current['auth-pass']}" unless current['auth-pass'].nil? %>
+<% end %>
 # sentinel down-after-milliseconds <master-name> <milliseconds>
 #
 # Number of milliseconds the master (or any attached slave or sentinel) should
@@ -53,16 +57,20 @@ sentinel monitor <%=@name%> <%=@masterip%> <%=@masterport%> <%= @quorum_count %>
 # Down).
 #
 # Default is 30 seconds.
-sentinel down-after-milliseconds <%=@name%> <%=@downaftermil%>
-
+<% @masters.each do |current| %>
+<% calc_name = current['master_name'].to_s || @name.to_s %>
+sentinel down-after-milliseconds <%=calc_name%> <%=current['down-after-milliseconds']%>
+<% end %>
 # sentinel parallel-syncs <master-name> <numslaves>
 #
 # How many slaves we can reconfigure to point to the new slave simultaneously
 # during the failover. Use a low number if you use the slaves to serve query
 # to avoid that all the slaves will be unreachable at about the same
 # time while performing the synchronization with the master.
-sentinel parallel-syncs <%=@name%> <%=@parallelsyncs%>
-
+<% @masters.each do |current| %>
+<% calc_name = current['master_name'].to_s || @name.to_s %>
+sentinel parallel-syncs <%=calc_name%> <%=current['parallel-syncs']%>
+<% end %>
 # sentinel failover-timeout <master-name> <milliseconds>
 #
 # Specifies the failover timeout in milliseconds. When this time has elapsed
@@ -77,8 +85,10 @@ sentinel parallel-syncs <%=@name%> <%=@parallelsyncs%>
 # "takeover".
 #
 # Default is 15 minutes.
-sentinel failover-timeout <%=@name%> <%=@failovertimeout%>
-
+<% @masters.each do |current| %>
+<% calc_name = current['master_name'].to_s || @name.to_s %>
+sentinel failover-timeout <%=calc_name%> <%=current['failover-timeout']%>
+<% end %>
 # SCRIPTS EXECUTION
 #
 # sentinel notification-script and sentinel reconfig-script are used in order

--- a/test/integration/helpers/serverspec/sentinel_examples.rb
+++ b/test/integration/helpers/serverspec/sentinel_examples.rb
@@ -1,6 +1,7 @@
-shared_examples_for 'sentinel on port' do |redis_port, args|
+shared_examples_for 'sentinel on port' do |redis_port, redis_instance_name, args|
   it 'enables the redis-sentinel service' do
-    expect(service 'redis_sentinel_mycluster').to be_enabled
+    name = redis_instance_name || 'redis_sentinel_mycluster'
+    expect(service name).to be_enabled
   end
 
   context 'starts the redis-setinel service' do

--- a/test/integration/multisentinel/serverspec/multiple_sentinels_spec.rb
+++ b/test/integration/multisentinel/serverspec/multiple_sentinels_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+
+describe 'Redis-Sentinel' do
+  it_behaves_like 'sentinel on port', 26379, 'redis_sentinel_cluster'
+end
+
+describe file('/etc/redis/sentinel_cluster.conf') do
+  [
+    %r{sentinel monitor master6379 127.0.0.1 6379 2},
+    %r{sentinel down-after-milliseconds master6379 30000},
+    %r{sentinel parallel-syncs master6379 1},
+    %r{sentinel failover-timeout master6379 900000},
+    %r{sentinel monitor master6380 127.0.0.1 6380 2},
+    %r{sentinel down-after-milliseconds master6380 30000},
+    %r{sentinel parallel-syncs master6380 1},
+    %r{sentinel failover-timeout master6380 900000}
+  ].each do |pattern|
+    its(:content) { should match(pattern) }
+  end
+end
+
+describe command('/usr/local/bin/redis-cli --raw -p 26379 SENTINEL MASTER master6379') do
+  [
+    %r{name},
+    %r{master6379},
+    %r{ip},
+    %r{127.0.0.1},
+    %r{port},
+    %r{6379},
+    %r{flags},
+    %r{master},
+    %r{last-ping-sent},
+    %r{last-ok-ping-reply},
+    %r{last-ping-reply},
+    %r{down-after-milliseconds},
+    %r{30000},
+    %r{role-reported},
+    %r{master},
+    %r{config-epoch},
+    %r{0},
+    %r{num-slaves},
+    %r{0},
+    %r{num-other-sentinels},
+    %r{0},
+    %r{quorum},
+    %r{2},
+    %r{failover-timeout},
+    %r{900000},
+    %r{parallel-syncs},
+    %r{1}
+  ].each do |pattern|
+    its(:stdout) { should match(pattern) }
+  end
+end
+
+describe command('/usr/local/bin/redis-cli --raw -p 26379 SENTINEL MASTER master6380') do
+  [
+    %r{name},
+    %r{master6380},
+    %r{ip},
+    %r{127.0.0.1},
+    %r{port},
+    %r{6380},
+    %r{flags},
+    %r{master},
+    %r{last-ping-sent},
+    %r{last-ok-ping-reply},
+    %r{last-ping-reply},
+    %r{down-after-milliseconds},
+    %r{30000},
+    %r{role-reported},
+    %r{master},
+    %r{config-epoch},
+    %r{0},
+    %r{num-slaves},
+    %r{0},
+    %r{num-other-sentinels},
+    %r{0},
+    %r{quorum},
+    %r{2},
+    %r{failover-timeout},
+    %r{900000},
+    %r{parallel-syncs},
+    %r{1}
+  ].each do |pattern|
+    its(:stdout) { should match(pattern) }
+  end
+end

--- a/test/unit/spec/sentinel_spec.rb
+++ b/test/unit/spec/sentinel_spec.rb
@@ -9,7 +9,13 @@ describe 'sentinel recipes' do
   # pick an arbitrary OS; just for fauxhai to provide some values
   it 'creates a default sentinel instance' do
     chef_run = ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '14.04').converge(*recipes) # *splat operator for array to vararg
-    expect(chef_run).to run_redisio_sentinel('redis-sentinels').with(sentinels: [{"port"=>"26379", "name"=>"mycluster", "master_ip"=>"127.0.0.1", "master_port"=>6379}])
+    expect(chef_run).to run_redisio_sentinel('redis-sentinels').with(
+      sentinels: [{
+        "sentinel_port"=>"26379",
+        "name"=>"mycluster",
+        "masters" => [{"master_name"=>"mycluster_master", "master_ip"=>"127.0.0.1", "master_port"=>"6379"}]
+        }]
+    )
   end
 
   it 'creates a specified sentinel instance' do


### PR DESCRIPTION
- Add support in sentinel resource for an array of masters to monitor, with backwards compatibility for the older attributes, fixes #73. Replaces #87.
- Introduce a test-kitchen test for sentinel watching multiple masters.
- Incidentally, fixes #193 as well, since it adds a master name attribute for each master.