### PR TITLE
Added support for binding sentinels to a 'sentinel_address'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ The sentinel recipe's use their own attribute file.
 'user'                    => 'redis',
 'configdir'               => '/etc/redis',
 'sentinel_port'           => 26379,
+'sentinel_address'        => nil,
 'monitor'                 => nil,
 'down-after-milliseconds' => 30000,
 'can-failover'            => 'yes',

--- a/attributes/redis_sentinel.rb
+++ b/attributes/redis_sentinel.rb
@@ -20,6 +20,7 @@ default['redisio']['sentinel_defaults'] = {
   'user'                    => 'redis',
   'configdir'               => '/etc/redis',
   'sentinel_port'           => 26379,
+  'sentinel_address'        => nil,
   'monitor'                 => nil,
   'down-after-milliseconds' => 30000,
   'can-failover'            => 'yes',

--- a/providers/sentinel.rb
+++ b/providers/sentinel.rb
@@ -145,6 +145,7 @@ def configure
           :piddir                 => piddir,
           :job_control            => node['redisio']['job_control'],
           :sentinel_port          => current['sentinel_port'],
+          :sentinel_address       => current['sentinel_address'],
           :loglevel               => current['loglevel'],
           :logfile                => current['logfile'],
           :syslogenabled          => current['syslogenabled'],

--- a/recipes/sentinel.rb
+++ b/recipes/sentinel.rb
@@ -27,6 +27,7 @@ sentinel_instances = redis['sentinels']
 if sentinel_instances.nil?
   sentinel_instances = [{
     'sentinel_port' => '26379',
+    'sentinel_address' => nil,
     'name' => 'mycluster',
     'masters' => [{
       'master_name' => 'mycluster_master',

--- a/recipes/sentinel_enable.rb
+++ b/recipes/sentinel_enable.rb
@@ -21,7 +21,7 @@
 sentinel_instances = node['redisio']['sentinels']
 
 if sentinel_instances.nil?
-  sentinel_instances = [{'sentinel_port' => '26379', 'name' => 'mycluster', 'master_ip' => '127.0.0.1', 'master_port' => '6379'}]
+  sentinel_instances = [{'sentinel_port' => '26379', 'sentinel_address' => nil, 'name' => 'mycluster', 'master_ip' => '127.0.0.1', 'master_port' => '6379'}]
 end
 
 execute 'reload-systemd' do

--- a/templates/default/sentinel.conf.erb
+++ b/templates/default/sentinel.conf.erb
@@ -15,6 +15,14 @@ syslog-facility <%= @syslogfacility %>
 # The port that this sentinel instance will run on
 port <%=@sentinel_port%>
 
+# If you want you can bind a single interface, if the bind option is not
+# specified all the interfaces will listen for incoming connections.
+#
+# bind 127.0.0.1
+<% unless @sentinel_address.nil? %>
+  <%= "bind #{@sentinel_address.respond_to?(:join) ? @sentinel_address.join(" ") : @sentinel_address }" %>
+<% end %>
+
 # sentinel monitor <master-name> <ip> <redis-port> <quorum>
 #
 # Tells Sentinel to monitor this slave, and to consider it in O_DOWN

--- a/test/unit/spec/sentinel_spec.rb
+++ b/test/unit/spec/sentinel_spec.rb
@@ -12,6 +12,7 @@ describe 'sentinel recipes' do
     expect(chef_run).to run_redisio_sentinel('redis-sentinels').with(
       sentinels: [{
         "sentinel_port"=>"26379",
+        "sentinel_address"=>nil,
         "name"=>"mycluster",
         "masters" => [{"master_name"=>"mycluster_master", "master_ip"=>"127.0.0.1", "master_port"=>"6379"}]
         }]
@@ -22,12 +23,13 @@ describe 'sentinel recipes' do
     chef_run = ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '14.04') do |node|
       node.set['redisio']['sentinels'] = [{
           "sentinel_port"=>"1234",
+          "sentinel_address"=>"127.0.0.1",
           "name"=>"sentinel-test-params",
           "master_ip"=>"5.6.7.8",
           "master_port"=>9123
       }]
     end.converge(*recipes) # *splat operator for array to vararg
-    expect(chef_run).to run_redisio_sentinel('redis-sentinels').with(sentinels: [{"sentinel_port"=>"1234", "name"=>"sentinel-test-params", "master_ip"=>"5.6.7.8", "master_port"=>9123}])
+    expect(chef_run).to run_redisio_sentinel('redis-sentinels').with(sentinels: [{"sentinel_port"=>"1234", "sentinel_address"=>"127.0.0.1","name"=>"sentinel-test-params", "master_ip"=>"5.6.7.8", "master_port"=>9123}])
   end
 
   it 'should not create a sentinel instance' do


### PR DESCRIPTION
This PR adds a new optional `sentinel_address` attribute to bind the sentinel to a single (or multiple) interfaces. If the attribute is not specified then the sentinel will listen on all interfaces (as today).
