### PR TITLE
Add Centos7 and Systemd Support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,6 +14,9 @@ platforms:
     run_list:
       - recipe[yum-epel::default]
       - recipe[yum-remi::default]
+  - name: centos-7.1
+    run_list:
+      - recipe[yum-epel::default]
   - name: fedora-20
 
 suites:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Tested on:
 * Ubuntu 12.04
 * Debian 6.0.8
 * Fedora 20
-* Centos 6.4
+* Centos 6.6
+* Centos 7.1
 
 Usage
 =====

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -55,8 +55,12 @@ end
 # Custom installation directory
 default['redisio']['install_dir'] = nil
 
-# Job control related options (initd or upstart)
-default['redisio']['job_control'] = 'initd'
+# Job control related options (initd, upstart, or systemd)
+if node['platform_family'] == 'rhel' && Gem::Version.new(node['platform_version']) > Gem::Version.new('7.0.0')
+  default['redisio']['job_control'] = 'systemd'
+else
+  default['redisio']['job_control'] = 'initd'
+end
 
 # Init.d script related options
 default['redisio']['init.d']['required_start'] = []

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'brian.bianco@gmail.com'
 license          'Apache 2.0'
 description      'Installs/Configures redis'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.3.1'
+version          '2.4.0'
 %w[ debian ubuntu centos redhat fedora scientific suse amazon].each do |os|
   supports os
 end

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -47,19 +47,19 @@ redis_instances.each do |current_server|
 
   case node['redisio']['job_control']
   when 'initd'
-  	service "redis#{server_name}" do
+    service "redis#{server_name}" do
       # don't supply start/stop/restart commands, Chef::Provider::Service::*
       # do a fine job on it's own, and support systemd correctly
       supports :start => true, :stop => true, :restart => false, :status => true
-  	end
+    end
   when 'upstart'
-  	service "redis#{server_name}" do
+    service "redis#{server_name}" do
       provider Chef::Provider::Service::Upstart
       start_command "start redis#{server_name}"
       stop_command "stop redis#{server_name}"
       restart_command "restart redis#{server_name}"
       supports :start => true, :stop => true, :restart => true, :status => false
-  	end
+    end
   when 'systemd'
     service "redis@#{server_name}" do
       provider Chef::Provider::Service::Systemd

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -34,25 +34,37 @@ redisio_configure "redis-servers" do
   base_piddir redis['base_piddir']
 end
 
+template '/usr/lib/systemd/system/redis@.service' do
+  source    'redis@.service.erb'
+  variables({ :bin_path => node['redisio']['bin_path'] })
+  only_if   { node['redisio']['job_control'] == 'systemd' }
+end
+
 # Create a service resource for each redis instance, named for the port it runs on.
 redis_instances.each do |current_server|
   server_name = current_server['name'] || current_server['port']
   job_control = node['redisio']['job_control']
 
-  if job_control == 'initd'
+  case node['redisio']['job_control']
+  when 'initd'
   	service "redis#{server_name}" do
       # don't supply start/stop/restart commands, Chef::Provider::Service::*
       # do a fine job on it's own, and support systemd correctly
       supports :start => true, :stop => true, :restart => false, :status => true
   	end
-  elsif job_control == 'upstart'
+  when 'upstart'
   	service "redis#{server_name}" do
-	  provider Chef::Provider::Service::Upstart
+      provider Chef::Provider::Service::Upstart
       start_command "start redis#{server_name}"
       stop_command "stop redis#{server_name}"
       restart_command "restart redis#{server_name}"
       supports :start => true, :stop => true, :restart => true, :status => false
   	end
+  when 'systemd'
+    service "redis@#{server_name}" do
+      provider Chef::Provider::Service::Systemd
+      supports :start => true, :stop => true, :restart => true, :status => true
+    end
   else
     Chef::Log.error("Unknown job control type, no service resource created!")
   end

--- a/recipes/enable.rb
+++ b/recipes/enable.rb
@@ -20,10 +20,28 @@
 
 redis = node['redisio']
 
+execute 'reload-systemd' do
+  command '/usr/bin/systemctl daemon-reload'
+  only_if { node['redisio']['job_control'] == 'systemd'}
+  action :nothing
+end
+
 redis['servers'].each do |current_server|
   server_name = current_server["name"] || current_server["port"]
-  resource = resources("service[redis#{server_name}]")
+  resource_name = if node['redisio']['job_control'] == 'systemd'
+                    "service[redis@#{server_name}]"
+                  else
+                    "service[redis#{server_name}]"
+                  end
+  resource = resources(resource_name)
   resource.action Array(resource.action)
   resource.action << :start
-  resource.action << :enable
+  if node['redisio']['job_control'] != 'systemd'
+    resource.action << :enable
+  else
+    link "/etc/systemd/system/multi-user.target.wants/redis@#{server_name}.service" do
+      to '/usr/lib/systemd/system/redis@.service'
+      notifies :run, 'execute[reload-systemd]', :immediately
+    end
+  end
 end

--- a/recipes/sentinel.rb
+++ b/recipes/sentinel.rb
@@ -54,11 +54,11 @@ sentinel_instances.each do |current_sentinel|
 
   case node['redisio']['job_control']
   when 'initd'
-  	service "redis_sentinel_#{sentinel_name}" do
+    service "redis_sentinel_#{sentinel_name}" do
       # don't supply start/stop/restart commands, Chef::Provider::Service::*
       # do a fine job on it's own, and support systemd correctly
       supports :start => true, :stop => true, :restart => true, :status => false
-  	end
+    end
   when 'upstart'
     service "redis_sentinel_#{sentinel_name}" do
       provider Chef::Provider::Service::Upstart
@@ -68,10 +68,10 @@ sentinel_instances.each do |current_sentinel|
       supports :start => true, :stop => true, :restart => true, :status => false
     end
   when 'systemd'
-  	service "redis-sentinel@#{sentinel_name}" do
+    service "redis-sentinel@#{sentinel_name}" do
       provider Chef::Provider::Service::Systemd
       supports :start => true, :stop => true, :restart => true, :status => true 
-  	end
+    end
   else
     Chef::Log.error("Unknown job control type, no service resource created!")
   end

--- a/recipes/sentinel_enable.rb
+++ b/recipes/sentinel_enable.rb
@@ -24,10 +24,28 @@ if sentinel_instances.nil?
   sentinel_instances = [{'sentinel_port' => '26379', 'name' => 'mycluster', 'master_ip' => '127.0.0.1', 'master_port' => '6379'}]
 end
 
+execute 'reload-systemd' do
+  command '/usr/bin/systemctl daemon-reload'
+  only_if { node['redisio']['job_control'] == 'systemd'}
+  action :nothing
+end
+
 sentinel_instances.each do |current_sentinel|
   sentinel_name = current_sentinel['name']
-  resource = resources("service[redis_sentinel_#{sentinel_name}]")
+  resource_name = if node['redisio']['job_control'] == 'systemd'
+                    "service[redis-sentinel@#{sentinel_name}]"
+                  else
+                    "service[redis_sentinel_#{sentinel_name}]"
+                  end
+  resource = resources(resource_name)
   resource.action Array(resource.action)
   resource.action << :start
-  resource.action << :enable
+  if node['redisio']['job_control'] != 'systemd'
+    resource.action << :enable
+  else
+    link "/etc/systemd/system/multi-user.target.wants/redis@#{sentinel_name}.service" do
+      to '/usr/lib/systemd/system/redis-sentinel@.service'
+      notifies :run, 'execute[reload-systemd]', :immediately
+    end
+  end
 end

--- a/templates/default/redis-sentinel@.service
+++ b/templates/default/redis-sentinel@.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Redis persistent key-value database
+After=network.target
+
+[Service]
+ExecStart=<%= @bin_path %>/redis-server /etc/redis/sentinel_%i.conf --sentinel --daemonize no
+User=redis
+Group=redis
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/default/redis.conf.erb
+++ b/templates/default/redis.conf.erb
@@ -14,7 +14,7 @@
 
 # By default Redis does not run as a daemon. Use 'yes' if you need it.
 # Note that Redis will write a pid file in /var/run/redis.pid when daemonized.
-<% unless @job_control == 'upstart' %>
+<% if @job_control == 'initd' %>
 daemonize yes
 <% end %>
 

--- a/templates/default/redis@.service.erb
+++ b/templates/default/redis@.service.erb
@@ -1,0 +1,12 @@
+[Unit]
+Description=Redis persistent key-value database
+After=network.target
+
+[Service]
+ExecStart=<%= @bin_path %>/redis-server /etc/redis/%i.conf --daemonize no
+ExecStop=/usr/bin/redis-shutdown
+User=redis
+Group=redis
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/default/sentinel.conf.erb
+++ b/templates/default/sentinel.conf.erb
@@ -1,7 +1,7 @@
 # Example sentinel.conf
 
 # redisio Cookbook additions
-<% unless @job_control == 'upstart' %>
+<% if @job_control == 'initd' %>
 daemonize yes
 <% end %>
 pidfile <%= @piddir %>/sentinel_<%=@name%>.pid

--- a/test/integration/helpers/serverspec/redisio_examples.rb
+++ b/test/integration/helpers/serverspec/redisio_examples.rb
@@ -1,6 +1,11 @@
 shared_examples_for 'redis on port' do |redis_port, args|
   it 'enables the redis service' do
-    expect(service "redis#{redis_port}").to be_enabled
+    service_name = if os[:family] == 'redhat' and os[:release][0] == '7'
+                     "redis@#{redis_port}"
+                   else
+                     "redis#{redis_port}"
+                   end
+    expect(service service_name).to be_enabled
   end
 
   context 'starts the redis service' do

--- a/test/integration/helpers/serverspec/sentinel_examples.rb
+++ b/test/integration/helpers/serverspec/sentinel_examples.rb
@@ -1,6 +1,11 @@
-shared_examples_for 'sentinel on port' do |redis_port, redis_instance_name, args|
+shared_examples_for 'sentinel on port' do |redis_port, redis_cluster_name, args|
   it 'enables the redis-sentinel service' do
-    name = redis_instance_name || 'redis_sentinel_mycluster'
+    redis_cluster_name ||= 'mycluster'
+    name = if os[:family] == 'redhat' and os[:release][0] == '7'
+             "redis-sentinel@#{redis_cluster_name}"
+           else
+             "redis_sentinel_#{redis_cluster_name}"
+           end
     expect(service name).to be_enabled
   end
 

--- a/test/integration/multisentinel/serverspec/multiple_sentinels_spec.rb
+++ b/test/integration/multisentinel/serverspec/multiple_sentinels_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Redis-Sentinel' do
-  it_behaves_like 'sentinel on port', 26379, 'redis_sentinel_cluster'
+  it_behaves_like 'sentinel on port', 26379, 'cluster'
 end
 
 describe file('/etc/redis/sentinel_cluster.conf') do
@@ -19,15 +19,17 @@ describe file('/etc/redis/sentinel_cluster.conf') do
   end
 end
 
-describe file('/etc/init.d/redis_sentinel_cluster') do
-  [
-    %r{SENTINELNAME=sentinel_cluster},
-    %r{EXEC="su -s /bin/sh -c '/usr/local/bin/redis-server /etc/redis/\$\{SENTINELNAME\}.conf --sentinel' redis"},
-    %r{PIDFILE=/var/run/redis/sentinel_cluster/\$\{SENTINELNAME\}.pid},
-    %r{mkdir -p /var/run/redis/sentinel_cluster},
-    %r{chown redis  /var/run/redis/sentinel_cluster}
-  ].each do |pattern|
-    its(:content) { should match(pattern) }
+unless os[:family] == 'redhat' and os[:release][0] == '7'
+  describe file('/etc/init.d/redis_sentinel_cluster') do
+    [
+      %r{SENTINELNAME=sentinel_cluster},
+      %r{EXEC="(su -s /bin/sh)|(runuser redis) -c \\?["']/usr/local/bin/redis-server /etc/redis/\$\{SENTINELNAME\}.conf --sentinel\\?["']( redis)?"},
+      %r{PIDFILE=/var/run/redis/sentinel_cluster/\$\{SENTINELNAME\}.pid},
+      %r{mkdir -p /var/run/redis/sentinel_cluster},
+      %r{chown redis  /var/run/redis/sentinel_cluster}
+    ].each do |pattern|
+      its(:content) { should match(pattern) }
+    end
   end
 end
 


### PR DESCRIPTION
This PR adds support for centos 7 and systemd. The existing approach of writing several `init.d` scripts is a perfect fit for systemd templated unit files. Here's what I think are possibly non-obvious parts of the PR:

- The `link` resources added to `enable.rb` and `sentinel_enable.rb` are an analogue to enabling the service for templated systemd scripts.
- The change in the regex on line 26 (formerly 25) of `test/integration/multisentinel/serverspec/multiple_sentinels_spec.rb` fixes tests that fail for some versions of the templated init script. This isn't directly related to the rest of the PR, I just noticed it was failing for some distros when I was testing.

Let me know what you think. And thanks for maintaining such an easy-to-modify and well-tested cookbook! It was a joy to work on.