### PR TITLE
Fix bug. not valid `only_if` of `user_ulimit`

### DIFF
--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -171,9 +171,10 @@ def configure
         only_if { ::File.exists?(rdb_file) }
       end
       #Setup the redis users descriptor limits
-      user_ulimit current['user'] do
-        filehandle_limit descriptors
-        only_if { current['ulimit'] }
+      if current['ulimit']
+        user_ulimit current['user'] do
+          filehandle_limit descriptors
+        end
       end
 
       computed_save = current['save']


### PR DESCRIPTION
## Bug

`default["redisio"]["default_settings"]["ulimit"]` attribute set `nil`,  but it would have been made `/etc/security/limits.d/redis_limits.conf`

## Cause

`user_ulimit` is  `definition`, not `lwrp`. 
ref: https://github.com/bmhatfield/chef-ulimit/blob/master/definitions/user_ulimit.rb

Chef definition does not support nof_if/only_if.