### PR TITLE
add disable_os_default recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Recipes
 * redis_gem - This recipe can be used to install the redis ruby gem
 * sentinel - This recipe can be used to install and configure sentinel
 * sentinel_enable - This recipe can be used to enable the sentinel service(s)
+* disable_os_default - This recipe can be used to disable the default OS redis init script
 
 Role File Examples
 ------------------

--- a/metadata.rb
+++ b/metadata.rb
@@ -30,6 +30,7 @@ recipe 'redisio::sentinel_enable', 'This recipe is used enable sentinel init scr
 recipe 'redisio::enable', 'This recipe is used to start the redis instances and enable them in the default run levels'
 recipe 'redisio::disable', 'this recipe is used to stop the redis instances and disable them in the default run levels'
 recipe 'redisio::redis_gem', 'this recipe will install the redis ruby gem into the system ruby'
+recipe 'redisio::disable_os_default', 'This recipe is used to disable the default OS redis init script'
 
 depends 'ulimit', '>= 0.1.2'
 depends 'build-essential'

--- a/recipes/disable_os_default.rb
+++ b/recipes/disable_os_default.rb
@@ -1,0 +1,32 @@
+#
+# Cookbook Name:: redisio
+# Recipe:: disable_os_default
+#
+# Copyright 2013, Brian Bianco <brian.bianco@gmail.com>
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# disable the default OS redis init script
+service_name = case node['platform']
+               when 'debian', 'ubuntu'
+                 'redis-server'
+               when 'redhat', 'centos', 'fedora', 'scientific', 'suse', 'amazon'
+                 'redis'
+               end
+
+service service_name do
+  action [:stop, :disable]
+  only_if { service_name }
+end


### PR DESCRIPTION
When using redis from the ubuntu package, i use this simple recipe to disable the default OS init script.
Otherwise i can't use the init script provided by this recipe after a reboot.

Do you think something like this can be a useful addition?
