### PR TITLE
Support rename_command stanzas in redis.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ Available options and their defaults
 'replpingslaveperiod'     => '10',
 'repltimeout'             => '60',
 'requirepass'             => nil,
+'rename_commands'         => nil, or a hash where each key is a redis command and the value is the command's new name.
 'maxclients'              => 10000,
 'maxmemory'               => nil,
 'maxmemorypolicy'         => nil,

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -101,6 +101,7 @@ default['redisio']['default_settings'] = {
   'replpingslaveperiod'     => '10',
   'repltimeout'             => '60',
   'requirepass'             => nil,
+  'rename_commands'         => nil,
   'maxclients'              => 10000,
   'maxmemory'               => nil,
   'maxmemorypolicy'         => nil,

--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -218,6 +218,7 @@ def configure
           :replpingslaveperiod        => current['replpingslaveperiod'],
           :repltimeout                => current['repltimeout'],
           :requirepass                => current['requirepass'],
+          :rename_commands            => current['rename_commands'],
           :maxclients                 => current['maxclients'],
           :maxmemory                  => maxmemory,
           :maxmemorypolicy            => current['maxmemorypolicy'],

--- a/templates/default/redis.conf.erb
+++ b/templates/default/redis.conf.erb
@@ -239,6 +239,12 @@ repl-timeout <%=@repltimeout%>
 # an empty string:
 #
 # rename-command CONFIG ""
+<% if !@rename_commands.nil? %>
+  <% @rename_commands.each do |k, v| %>
+    <% v = '""' if v.empty? || v.nil? %>
+    <%= "rename-command #{k} #{v}" %>
+  <% end %>
+<% end %>
 
 ################################### LIMITS ####################################
 


### PR DESCRIPTION
Add an attribute, `rename_command', that accepts a hash of old => new
name translations.