### PR TITLE
Only create the sentinel config files once

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The disable recipe just stops redis and removes it from run levels.
 
 The cookbook also contains a recipe to allow for the installation of the redis ruby gem.
 
-Redis-sentinel will write configuration and state data back into its configuration file.  This creates obvious problems when that config is managed by chef.  There is an attribute set to true which controls if chef manages the redis-sentinel config.  By default chef will write out this config file and manage it.  If deploying sentinel it is recommended that you set the node[:redisio][:sentinel][:manage_config] to false allowing chef to write out the initial config and then allow redis-sentiniel to manage.  If running sentinel it is only advised to have node[:redisio][:sentinel][:manage_config] = true when you are pushing new changes to the config file as it will create a flapping state between chef and sentinel when sentinel writes out state to the file.
+Redis-sentinel will write configuration and state data back into its configuration file.  This creates obvious problems when that config is managed by chef. This cookbook will create the config file once, and then leave a breadcrumb that will guard against the file from being updated again.
 
 Recipes
 -------

--- a/attributes/redis_sentinel.rb
+++ b/attributes/redis_sentinel.rb
@@ -34,6 +34,6 @@ default['redisio']['sentinel_defaults'] = {
 
 # Manage Sentinel Config File
 ## Will write out the base config one time then no longer manage the config allowing sentinel to take over
-default['redisio']['sentinel']['manage_config'] = true
+default['redisio']['sentinel']['manage_config'] = true #deprecated
 
 default['redisio']['sentinels'] = nil

--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -86,13 +86,6 @@ def configure
 
     descriptors = current['ulimit'] == 0 ? current['maxclients'] + 32 : current['maxclients']
 
-    #Manage Redisio Config?
-    if node['redisio']['sentinel']['manage_config'] == true
-      config_action = :create
-    else
-      config_action = :create_if_missing
-    end
-
     recipe_eval do
       server_name = current['name'] || current['port']
       piddir = "#{base_piddir}/#{server_name}"
@@ -191,7 +184,7 @@ def configure
         owner current['user']
         group current['group']
         mode '0644'
-        action config_action
+        action :create
         variables({
           :version                    => version_hash,
           :piddir                     => piddir,
@@ -245,7 +238,14 @@ def configure
           :clusternodetimeout         => current['clusternodetimeout'],
           :includes                   => current['includes']
         })
+        not_if do ::File.exists?("#{current['datadir']}/#{server_name}.conf.breadcrumb") end
       end
+
+      file "#{current['datadir']}/#{server_name}.conf.breadcrumb" do
+        content "This file prevents the chef cookbook from overwritting the redis config more than once"
+        action :create_if_missing
+      end
+
       #Setup init.d file
 
       bin_path = node['redisio']['bin_path']

--- a/providers/sentinel.rb
+++ b/providers/sentinel.rb
@@ -35,12 +35,6 @@ def configure
     #Merge the configuration defaults with the provided array of configurations provided
     current = current_defaults_hash.merge(current_instance_hash)
 
-    #Manage Sentinel Configs?
-    if node['redisio']['sentinel']['manage_config'] == true
-      config_action = :create
-    else
-      config_action = :create_if_missing
-    end
 
     recipe_eval do
       sentinel_name = current['name'] || current['port']
@@ -143,7 +137,7 @@ def configure
         owner current['user']
         group current['group']
         mode '0644'
-        action config_action
+        action :create
         variables({
           :name                   => current['name'],
           :piddir                 => piddir,
@@ -155,6 +149,12 @@ def configure
           :syslogfacility         => current['syslogfacility'],
           :masters                => masters_with_defaults
         })
+        not_if do ::File.exists?("#{current['datadir']}/#{sentinel_name}.conf.breadcrumb") end
+      end
+
+      file "#{current['datadir']}/#{sentinel_name}.conf.breadcrumb" do
+        content "This file prevents the chef cookbook from overwritting the sentinel config more than once"
+        action :create_if_missing
       end
 
       #Setup init.d file


### PR DESCRIPTION
Discussion in #231

Todo:

- [ ] Should redis and sentinel be restarted the first time the config file changes?
- [x] Is /var/tmp the best location for this file
- [x] Improve documentation & warn about deprecation. 