### PR TITLE
use the config's ulimits if set and is > max_clients.

### DIFF
--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -84,7 +84,13 @@ def configure
       maxmemory = (node_memory_kb * 1024 * percent_factor / new_resource.servers.length).round.to_s
     end
 
-    descriptors = current['ulimit'] == 0 ? current['maxclients'] + 32 : current['maxclients']
+    if current['ulimit'] == 0
+      descriptors = current['maxclients'] + 32
+    elsif current['ulimit'] > current['maxclients']
+      descriptors = current['ulimit']
+    else
+      descriptors = current['maxclients']
+    end
 
     #Manage Redisio Config?
     if node['redisio']['sentinel']['manage_config'] == true


### PR DESCRIPTION
I spent a bit trying to figure out why setting config['ulimit'] was capping out at 10k (max_clients).  This fixes that, which lets someone control ulimits on the redis user while protecting against too small of a ulimit.