### PR TITLE
Fix typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Available options and their defaults
 'databases'               => '16',
 'backuptype'              => 'rdb',
 'datadir'                 => '/var/lib/redis',
-'unixoscket'              => nil - The location of the unix socket to use,
+'unixsocket'              => nil - The location of the unix socket to use,
 'unixsocketperm'          => nil - The permissions of the unix socket,
 'timeout'                 => '0',
 'keepalive'               => '0',


### PR DESCRIPTION
Not a huge typo, but was concerned when I did `Ctrl+F` on the page and couldn't find a `unixsocket` option.