### PR TITLE
Allow version to be specified for pacakge install

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -19,6 +19,7 @@
 if node['redisio']['package_install']
   package "redisio_package_name" do
     package_name node['redisio']['package_name']
+    version node['redisio']['version'] if node['redisio']['version']
     action :install
   end
 else


### PR DESCRIPTION
Currently `node['redisio']['version']` is only used for tar installs.  It should be available for package installs as well.