### PR TITLE
Only indicate install resource is updated when installation occurs

### DIFF
--- a/providers/install.rb
+++ b/providers/install.rb
@@ -20,12 +20,16 @@
 action :run do
   # Package install
   if node['redisio']['package_install']
-    package "redisio_package_name" do
+    package_resource = package 'redisio_package_name' do
       package_name node['redisio']['package_name']
       version node['redisio']['version']
-      action :install
+      action :nothing
     end
-  # Tarball install
+
+    package_resource.run_action(:install)
+    new_resource.updated_by_last_action(true) if package_resource.updated_by_last_action?
+
+    # Tarball install
   else
     @tarball = "#{new_resource.base_name}#{new_resource.version}.#{new_resource.artifact_type}"
 
@@ -35,9 +39,9 @@ action :run do
       unpack
       build
       install
+      new_resource.updated_by_last_action(true)
     end
   end
-  new_resource.updated_by_last_action(true)
 end
 
 def download


### PR DESCRIPTION
We want to subscribe to the installation resource to restart Redis when a new version is installed, but currently the cookbook indicates that the installation resource is updated every time it's run. This PR changes the behavior to only indicate the resource has been updated when installation actually takes place.