### PR TITLE
Match attributes with Readme  and Redis config directives

### DIFF
--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -245,9 +245,9 @@ def configure
           :clientoutputbufferlimit    => current['clientoutputbufferlimit'],
           :hz                         => current['hz'],
           :aofrewriteincrementalfsync => current['aofrewriteincrementalfsync'],
-          :clusterenabled             => current['clusterenabled'],
-          :clusterconfigfile          => current['clusterconfigfile'],
-          :clusternodetimeout         => current['clusternodetimeout'],
+          :clusterenabled             => current['cluster-enabled'],
+          :clusterconfigfile          => current['cluster-config-file'],
+          :clusternodetimeout         => current['cluster-node-timeout'],
           :includes                   => current['includes']
         })
         not_if do ::File.exists?("#{current['configdir']}/#{server_name}.conf.breadcrumb") end


### PR DESCRIPTION
On README.md cluster settings are hyphen separated, but provider wasn't looking for those attributes

https://github.com/brianbianco/redisio/blame/master/README.md#L338

I choose to stick to redis config directives and modify provider.