### PR TITLE
Add support for bind config attribute for Sentinel

### DIFF
--- a/providers/sentinel.rb
+++ b/providers/sentinel.rb
@@ -149,7 +149,8 @@ def configure
           :logfile                => current['logfile'],
           :syslogenabled          => current['syslogenabled'],
           :syslogfacility         => current['syslogfacility'],
-          :masters                => masters_with_defaults
+          :masters                => masters_with_defaults,
+          :address                => current['address'],
         })
         not_if do ::File.exists?("#{current['configdir']}/#{sentinel_name}.conf.breadcrumb") end
       end

--- a/templates/default/sentinel.conf.erb
+++ b/templates/default/sentinel.conf.erb
@@ -15,6 +15,14 @@ syslog-facility <%= @syslogfacility %>
 # The port that this sentinel instance will run on
 port <%=@sentinel_port%>
 
+# If you want you can bind a single interface, if the bind option is not
+# specified all the interfaces will listen for incoming connections.
+#
+# bind 127.0.0.1
+<% unless @address.nil? %>
+  <%= "bind #{@address.respond_to?(:join) ? @address.join(" ") : @address }" %>
+<% end %>
+
 # sentinel monitor <master-name> <ip> <redis-port> <quorum>
 #
 # Tells Sentinel to monitor this slave, and to consider it in O_DOWN


### PR DESCRIPTION
Redis 3.2 forces you to be explicit about it for security reasons.
Otherwise it starts in protected mode (no writes)
