### PR TITLE
corrected redis@.service stop string

### DIFF
--- a/templates/default/redis@.service.erb
+++ b/templates/default/redis@.service.erb
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 ExecStart=<%= @bin_path %>/redis-server /etc/redis/%i.conf --daemonize no
-ExecStop=/usr/bin/redis-shutdown
+ExecStop=/usr/bin/redis-shutdown /etc/redis/%i.conf
 User=redis
 Group=redis
 


### PR DESCRIPTION
to pervent stop service on default port, with "redis-shutdown" command in systemd file
