### PR TITLE
Added FreeBSD-10.3 support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,9 +20,6 @@ platforms:
       - recipe[yum-epel::default]
   - name: fedora-20
   - name: freebsd-10.3
-    attributes:
-      redisio:
-         package_install: true
 
 suites:
   - name: default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,6 +19,10 @@ platforms:
     run_list:
       - recipe[yum-epel::default]
   - name: fedora-20
+  - name: freebsd-10.3
+    attributes:
+      redisio:
+         package_install: true
 
 suites:
   - name: default
@@ -39,7 +43,7 @@ suites:
     attributes:
      redisio:
         servers:
-          - port: 6379,
+          - port: 6379
         package_install: true
         version:
     excludes:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Platforms
 
 * Debian, Ubuntu
 * CentOS, Red Hat, Fedora, Scientific Linux
+* FreeBSD
 
 Testing
 -------
@@ -39,6 +40,7 @@ Tested on:
 * Fedora 20
 * Centos 6.6
 * Centos 7.1
+* FreeBSD 10.3
 
 Usage
 =====
@@ -46,6 +48,7 @@ Usage
 The redisio cookbook contains LWRP for installing, configuring and managing redis and redis_sentinel.
 
 The install recipe can build, compile and install redis from sources or install from packages. The configure recipe will configure redis and setup service resources.  These resources will be named for the port of the redis server, unless a "name" attribute was specified.  Example names would be: service["redis6379"] or service["redismaster"] if the name attribute was "master".
+_NOTE: currently installation from source is not supported for FreeBSD_
 
 The most common use case for the redisio cookbook is to use the default recipe, followed by the enable recipe.  
 
@@ -54,6 +57,7 @@ Another common use case is to use the default, and then call the service resourc
 It is important to note that changing the configuration options of redis does not make them take effect on the next chef run.  Due to how redis works, you cannot reload a configuration without restarting the redis service.  Redis does not offer a reload option, in order to have new options be used redis must be stopped and started.
 
 You should make sure to set the ulimit for the user you want to run redis as to be higher than the max connections you allow.
+_NOTE: setting ulimit is not supported on FreeBSD since the ulimit cookbook doesn't support FreeBSD_
 
 The disable recipe just stops redis and removes it from run levels.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,6 +18,7 @@
 
 package_bin_path = '/usr/bin'
 config_dir = '/etc/redis'
+default_package_install = false
 
 case node['platform']
 when 'ubuntu','debian'
@@ -38,6 +39,7 @@ when 'freebsd'
   package_name = 'redis'
   package_bin_path = '/usr/local/bin'
   config_dir = '/usr/local/etc/redis'
+  default_package_install = true
 else
   shell = '/bin/sh'
   homedir = '/redis'
@@ -46,8 +48,8 @@ end
 
 # Install related attributes
 default['redisio']['safe_install'] = true
-default['redisio']['package_install'] = false
-default['redisio']['package_name'] = package_name
+default['redisio']['package_install'] = default_package_install
+default['redisio']['package_name'] =  package_name
 default['redisio']['bypass_setup'] = false
 
 # Tarball and download related defaults

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,6 +16,9 @@
 # limitations under the License.
 #
 
+package_bin_path = '/usr/bin'
+config_dir = '/etc/redis'
+
 case node['platform']
 when 'ubuntu','debian'
   shell = '/bin/false'
@@ -29,6 +32,12 @@ when 'fedora'
   shell = '/bin/sh'
   homedir = '/home' #this is necessary because selinux by default prevents the homedir from being managed in /var/lib/
   package_name = 'redis'
+when 'freebsd'
+  shell = '/bin/sh'
+  homedir = '/var/lib/redis'
+  package_name = 'redis'
+  package_bin_path = '/usr/local/bin'
+  config_dir = '/usr/local/etc/redis'
 else
   shell = '/bin/sh'
   homedir = '/redis'
@@ -62,6 +71,8 @@ default['redisio']['install_dir'] = nil
 # Job control related options (initd, upstart, or systemd)
 if node['platform_family'] == 'rhel' && Gem::Version.new(node['platform_version']) > Gem::Version.new('7.0.0')
   default['redisio']['job_control'] = 'systemd'
+elsif node['platform_family'] == 'freebsd'
+  default['redisio']['job_control'] = 'rcinit'
 else
   default['redisio']['job_control'] = 'initd'
 end
@@ -79,7 +90,7 @@ default['redisio']['default_settings'] = {
   'systemuser'              => true,
   'uid'                     => nil,
   'ulimit'                  => 0,
-  'configdir'               => '/etc/redis',
+  'configdir'               => config_dir,
   'name'                    => nil,
   'tcpbacklog'              => '511',
   'address'                 => nil,
@@ -150,7 +161,7 @@ default['redisio']['servers'] = nil
 
 # Define binary path
 if node['redisio']['package_install']
-  default['redisio']['bin_path'] = '/usr/bin'
+  default['redisio']['bin_path'] = package_bin_path
 else
   default['redisio']['bin_path'] = '/usr/local/bin'
 end

--- a/attributes/redis_sentinel.rb
+++ b/attributes/redis_sentinel.rb
@@ -16,9 +16,15 @@
 # limitations under the License.
 #
 
+config_dir = '/etc/redis'
+
+if node['platform_family'] == 'freebsd'
+  config_dir = '/usr/local/etc/redis'
+end
+
 default['redisio']['sentinel_defaults'] = {
   'user'                    => 'redis',
-  'configdir'               => '/etc/redis',
+  'configdir'               => config_dir,
   'sentinel_port'           => 26379,
   'monitor'                 => nil,
   'down-after-milliseconds' => 30000,

--- a/providers/install.rb
+++ b/providers/install.rb
@@ -29,11 +29,14 @@ action :run do
     package_resource.run_action(:install)
     new_resource.updated_by_last_action(true) if package_resource.updated_by_last_action?
 
-    # Tarball install
+# freeBSD does not support from source since ports does not support versioning (without a lot of hassle)
+elsif node.platform_family == 'freebsd'
+    fail 'Source install not supported for freebsd'
+  # Tarball install
   else
     @tarball = "#{new_resource.base_name}#{new_resource.version}.#{new_resource.artifact_type}"
 
-    unless ( current_resource.version == new_resource.version || (redis_exists? && new_resource.safe_install) )
+    unless current_resource.version == new_resource.version || (redis_exists? && new_resource.safe_install)
       Chef::Log.info("Installing Redis #{new_resource.version} from source")
       download
       unpack
@@ -54,19 +57,19 @@ end
 def unpack
   install_dir = "#{new_resource.base_name}#{new_resource.version}"
   case new_resource.artifact_type
-    when "tar.gz",".tgz"
-      execute %(cd #{new_resource.download_dir} ; mkdir -p '#{install_dir}' ; tar zxf '#{@tarball}' --strip-components=1 -C '#{install_dir}' --no-same-owner)
-    else
-      raise Chef::Exceptions::UnsupportedAction, "Current package type #{new_resource.artifact_type} is unsupported"
+  when 'tar.gz', '.tgz'
+    execute %(cd #{new_resource.download_dir} ; mkdir -p '#{install_dir}' ; tar zxf '#{@tarball}' --strip-components=1 -C '#{install_dir}' --no-same-owner)
+  else
+    fail Chef::Exceptions::UnsupportedAction, "Current package type #{new_resource.artifact_type} is unsupported"
   end
 end
 
 def build
-  execute"cd #{new_resource.download_dir}/#{new_resource.base_name}#{new_resource.version} && make clean && make"
+  execute "cd #{new_resource.download_dir}/#{new_resource.base_name}#{new_resource.version} && make clean && make"
 end
 
 def install
-  install_prefix = ""
+  install_prefix = ''
   install_prefix = "PREFIX=#{new_resource.install_dir}" if new_resource.install_dir
   execute "cd #{new_resource.download_dir}/#{new_resource.base_name}#{new_resource.version} && make #{install_prefix} install"
   new_resource.updated_by_last_action(true)
@@ -76,7 +79,7 @@ def redis_exists?
   bin_path = node['redisio']['bin_path']
   bin_path = ::File.join(node['redisio']['install_dir'], 'bin') if node['redisio']['install_dir']
   redis_server = ::File.join(bin_path, 'redis-server')
-  ::File.exists?(redis_server)
+  ::File.exist?(redis_server)
 end
 
 def version
@@ -86,9 +89,9 @@ def version
     redis_server = ::File.join(bin_path, 'redis-server')
     redis_version = Mixlib::ShellOut.new("#{redis_server} -v")
     redis_version.run_command
-    version = redis_version.stdout[/version (\d*.\d*.\d*)/,1] || redis_version.stdout[/v=(\d*.\d*.\d*)/,1]
+    version = redis_version.stdout[/version (\d*.\d*.\d*)/, 1] || redis_version.stdout[/v=(\d*.\d*.\d*)/, 1]
     Chef::Log.info("The Redis server version is: #{version}")
-    return version.gsub("\n",'')
+    return version.delete("\n")
   end
   nil
 end

--- a/providers/sentinel.rb
+++ b/providers/sentinel.rb
@@ -54,7 +54,7 @@ def configure
       #Create the redis configuration directory
       directory current['configdir'] do
         owner 'root'
-        group 'root'
+        group node['platform_family'] == 'freebsd' ? 'wheel' : 'root'
         mode '0755'
         recursive true
         action :create
@@ -198,6 +198,25 @@ def configure
           })
         only_if { node['redisio']['job_control'] == 'upstart' }
       end
+      #TODO: fix for freebsd
+       template "/usr/local/etc/rc.d/redis_#{sentinel_name}" do
+          source 'sentinel.rcinit.erb'
+          cookbook 'redisio'
+          owner current['user']
+          group current['group']
+          mode '0755'
+          variables({
+            :name => sentinel_name,
+            :bin_path => bin_path,
+            :job_control => node['redisio']['job_control'],
+            :user => current['user'],
+            :group => current['group'],
+            :configdir => current['configdir'],
+            :piddir => piddir,
+            :platform => node['platform'],
+            })
+          only_if { node['redisio']['job_control'] == 'rcinit' }
+        end
     end
   end # servers each loop
 end

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -65,6 +65,11 @@ redis_instances.each do |current_server|
       provider Chef::Provider::Service::Systemd
       supports :start => true, :stop => true, :restart => true, :status => true
     end
+  when 'rcinit'
+    service "redis#{server_name}" do
+      provider Chef::Provider::Service::Freebsd
+      supports :start => true, :stop => true, :restart => true, :status => true
+    end
   else
     Chef::Log.error("Unknown job control type, no service resource created!")
   end

--- a/recipes/sentinel.rb
+++ b/recipes/sentinel.rb
@@ -70,7 +70,12 @@ sentinel_instances.each do |current_sentinel|
   when 'systemd'
     service "redis-sentinel@#{sentinel_name}" do
       provider Chef::Provider::Service::Systemd
-      supports :start => true, :stop => true, :restart => true, :status => true 
+      supports :start => true, :stop => true, :restart => true, :status => true
+    end
+  when 'rcinit'
+    service "redis_sentinel_#{sentinel_name}" do
+      provider Chef::Provider::Service::Freebsd
+      supports :start => true, :stop => true, :restart => true, :status => true
     end
   else
     Chef::Log.error("Unknown job control type, no service resource created!")

--- a/templates/default/redis.conf.erb
+++ b/templates/default/redis.conf.erb
@@ -14,7 +14,7 @@
 
 # By default Redis does not run as a daemon. Use 'yes' if you need it.
 # Note that Redis will write a pid file in /var/run/redis.pid when daemonized.
-<% if @job_control == 'initd' %>
+<% if @job_control == 'initd' || @job_control == 'rcinit' %>
 daemonize yes
 <% end %>
 

--- a/templates/default/redis.rcinit.erb
+++ b/templates/default/redis.rcinit.erb
@@ -1,0 +1,69 @@
+#!/bin/sh
+#
+#
+
+# PROVIDE: redis<%= @name %>
+# REQUIRE: LOGIN
+# BEFORE:  securelevel
+# KEYWORD: shutdown
+
+# Add the following line to /etc/rc.conf to enable `redis':
+#
+#redis<%= @name %>_enable="YES"
+#
+# Define profiles here to run separate redis instances:
+#
+#redis_profiles="foo bar" #  Script uses /usr/local/etc/redis-NAME.conf respectively.
+#                            For correct script working please update pidfile entries in
+#                            redis-NAME.conf files.
+
+. /etc/rc.subr
+
+name="redis<%= @name %>"
+rcvar="${name}_enable"
+
+extra_commands="reload"
+
+command="<%= File.join(@bin_path, 'redis-server') %>"
+pidfile="<%= @piddir %>/redis_<%=@name%>.pid"
+
+# read configuration and set defaults
+load_rc_config "$name"
+: ${redis<%= @name %>_enable="NO"}
+: ${redis_user="<%= @user %>"}
+: ${redis_config="<%= @configdir %>/<%= @name %>.conf"}
+
+command_args="${redis_config}"
+required_files="${redis_config}"
+
+_profile_exists() {
+        for _p in ${redis_profiles}; do
+                [ "${_p}" = "$1" ] && return 1;
+        done
+        return 0
+}
+
+if [ $# -eq 2 ]; then
+        _profile=$2
+        _profile_exists $_profile
+        _exists=$?
+        [ ${_exists} -ne 1 ] && {
+                echo "`basename /usr/local/etc/rc.d/redis`: no '$2' in 'redis_profiles'"
+                exit 1
+        };
+        echo "-- Profile: ${name} --"
+        config_file="/usr/local/etc/redis/${name}.conf"
+        command_args="${config_file}"
+        pidfile="<%= @piddir %>/${name}.pid"
+        required_files="${config_file}"
+elif [ -n "${redis_profiles}" ]; then
+        _swap=$*; shift; _profiles=$*
+        _profiles=${_profiles:-${redis_profiles}}
+        set -- ${_swap}
+        for _profile in ${_profiles}; do
+                /usr/local/etc/rc.d/redis $1 ${_profile}
+        done
+        exit 0
+fi
+
+run_rc_command "$1"

--- a/templates/default/sentinel.conf.erb
+++ b/templates/default/sentinel.conf.erb
@@ -1,7 +1,7 @@
 # Example sentinel.conf
 
 # redisio Cookbook additions
-<% if @job_control == 'initd' %>
+<% if @job_control == 'initd' || @job_control == 'rcinit' %>
 daemonize yes
 <% end %>
 pidfile <%= @piddir %>/sentinel_<%=@name%>.pid

--- a/templates/default/sentinel.rcinit.erb
+++ b/templates/default/sentinel.rcinit.erb
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# PROVIDE: sentinel_<%=@name%>
+# REQUIRE: LOGIN
+# BEFORE:  securelevel
+# KEYWORD: shutdown
+
+# Add the following line to /etc/rc.conf to enable `sentinel':
+#
+#redis_<%= @name %>_enable="YES"
+#
+
+. /etc/rc.subr
+
+name="redis_<%= @name %>"
+rcvar="${name}_enable"
+
+command="<%= File.join(@bin_path, 'redis-sentinel') %>"
+pidfile="<%= @piddir %>/<%=@name%>.pid"
+
+# read configuration and set defaults
+load_rc_config "$name"
+: ${sentinel_enable="NO"}
+: ${sentinel_user="<%= @user %>"}
+: ${sentinel_config="<%= @configdir %>/<%= @name %>.conf"}
+
+command_args="${sentinel_config} --daemonize yes --pidfile ${pidfile}"
+required_files="${sentinel_config}"
+start_precmd="sentinel_checks"
+restart_precmd="sentinel_checks"
+
+sentinel_checks()
+{
+    if [ x`id -u ${sentinel_user}` != x`stat -f %u ${sentinel_config}` ]; then
+	err 1 "${sentinel_config} must be owned by user ${sentinel_user}"
+    fi
+}
+
+run_rc_command "$1"

--- a/test/integration/default/serverspec/redisio_spec.rb
+++ b/test/integration/default/serverspec/redisio_spec.rb
@@ -4,11 +4,22 @@ describe 'Redis' do
   it_behaves_like 'redis on port', 6379
 end
 
-describe file('/etc/redis/savetest.conf') do
-  it { should be_file }
+if os[:family] == 'freebsd'
+  describe file('/usr/local/etc/redis/savetest.conf') do
+    it { should be_file }
 
-  ['save a', 'save b', 'save c'].each do |m|
-    its(:content) { should match(m) }
+    ['save a', 'save b', 'save c'].each do |m|
+      its(:content) { should match(m) }
+    end
+
   end
+else
+  describe file('/usr/etc/redis/savetest.conf') do
+    it { should be_file }
 
+    ['save a', 'save b', 'save c'].each do |m|
+      its(:content) { should match(m) }
+    end
+
+  end
 end

--- a/test/integration/default/serverspec/redisio_spec.rb
+++ b/test/integration/default/serverspec/redisio_spec.rb
@@ -14,7 +14,7 @@ if os[:family] == 'freebsd'
 
   end
 else
-  describe file('/usr/etc/redis/savetest.conf') do
+  describe file('/etc/redis/savetest.conf') do
     it { should be_file }
 
     ['save a', 'save b', 'save c'].each do |m|

--- a/test/integration/helpers/serverspec/redisio_examples.rb
+++ b/test/integration/helpers/serverspec/redisio_examples.rb
@@ -1,19 +1,18 @@
 shared_examples_for 'redis on port' do |redis_port, args|
-  it 'enables the redis service' do
+  it 'enables and starts the redis service' do
     service_name = if os[:family] == 'redhat' and os[:release][0] == '7'
                      "redis@#{redis_port}"
                    else
                      "redis#{redis_port}"
                    end
     expect(service service_name).to be_enabled
+    expect(service service_name).to be_running, :if => os[:family] != 'fedora'
   end
 
-  context 'starts the redis service' do
-    # We use grep and commands here, since serverspec only checks systemd on fedora 20
-    # instead of also being able to check sysv style init systems.
-    describe command("ps aux | grep -v grep | grep 'redis-server' | grep '*:#{redis_port}'") do
-      its(:exit_status) { should eq(0) }
-    end
+  # We use grep and commands here, since serverspec only checks systemd on fedora 20
+  # instead of also being able to check sysv style init systems.
+  describe command("ps aux | grep -v grep | grep 'redis-server' | grep '*:#{redis_port}'"), :if => os[:family] == 'fedora' do
+    its(:exit_status) { should eq(0) }
   end
 
   it "is listening on port #{redis_port}" do

--- a/test/integration/helpers/serverspec/sentinel_examples.rb
+++ b/test/integration/helpers/serverspec/sentinel_examples.rb
@@ -1,5 +1,5 @@
 shared_examples_for 'sentinel on port' do |redis_port, redis_cluster_name, args|
-  it 'enables the redis-sentinel service' do
+  it 'enables and starts the redis-sentinel service' do
     redis_cluster_name ||= 'mycluster'
     name = if os[:family] == 'redhat' and os[:release][0] == '7'
              "redis-sentinel@#{redis_cluster_name}"
@@ -7,13 +7,13 @@ shared_examples_for 'sentinel on port' do |redis_port, redis_cluster_name, args|
              "redis_sentinel_#{redis_cluster_name}"
            end
     expect(service name).to be_enabled
+    expect(service name).to be_running, :if => os[:family] != 'fedora'
   end
 
-  context 'starts the redis-setinel service' do
-    describe command("ps aux | grep -v grep | grep 'redis-server' | grep '*:#{redis_port}'") do
-      its(:exit_status) { should eq(0) }
-    end
+  describe command("ps aux | grep -v grep | grep 'redis-server' | grep '*:#{redis_port}'"), :if => os[:family] == 'fedora' do
+    its(:exit_status) { should eq(0) }
   end
+
 
   it "is listening on port #{redis_port}" do
     expect(port redis_port).to be_listening

--- a/test/integration/multisentinel/serverspec/multiple_sentinels_spec.rb
+++ b/test/integration/multisentinel/serverspec/multiple_sentinels_spec.rb
@@ -4,22 +4,39 @@ describe 'Redis-Sentinel' do
   it_behaves_like 'sentinel on port', 26379, 'cluster'
 end
 
-describe file('/etc/redis/sentinel_cluster.conf') do
-  [
-    %r{sentinel monitor master6379 127.0.0.1 6379 2},
-    %r{sentinel down-after-milliseconds master6379 30000},
-    %r{sentinel parallel-syncs master6379 1},
-    %r{sentinel failover-timeout master6379 900000},
-    %r{sentinel monitor master6380 127.0.0.1 6380 2},
-    %r{sentinel down-after-milliseconds master6380 30000},
-    %r{sentinel parallel-syncs master6380 1},
-    %r{sentinel failover-timeout master6380 900000}
-  ].each do |pattern|
-    its(:content) { should match(pattern) }
+if os[:family] == 'freebsd'
+  describe file('/usr/local/etc/redis/sentinel_cluster.conf') do
+    [
+      %r{sentinel monitor master6379 127.0.0.1 6379 2},
+      %r{sentinel down-after-milliseconds master6379 30000},
+      %r{sentinel parallel-syncs master6379 1},
+      %r{sentinel failover-timeout master6379 900000},
+      %r{sentinel monitor master6380 127.0.0.1 6380 2},
+      %r{sentinel down-after-milliseconds master6380 30000},
+      %r{sentinel parallel-syncs master6380 1},
+      %r{sentinel failover-timeout master6380 900000}
+    ].each do |pattern|
+      its(:content) { should match(pattern) }
+    end
+  end
+else
+  describe file('/etc/redis/sentinel_cluster.conf') do
+    [
+      %r{sentinel monitor master6379 127.0.0.1 6379 2},
+      %r{sentinel down-after-milliseconds master6379 30000},
+      %r{sentinel parallel-syncs master6379 1},
+      %r{sentinel failover-timeout master6379 900000},
+      %r{sentinel monitor master6380 127.0.0.1 6380 2},
+      %r{sentinel down-after-milliseconds master6380 30000},
+      %r{sentinel parallel-syncs master6380 1},
+      %r{sentinel failover-timeout master6380 900000}
+    ].each do |pattern|
+      its(:content) { should match(pattern) }
+    end
   end
 end
 
-unless os[:family] == 'redhat' and os[:release][0] == '7'
+unless (os[:family] == 'redhat' and os[:release][0] == '7') or os[:family] == 'freebsd'
   describe file('/etc/init.d/redis_sentinel_cluster') do
     [
       %r{SENTINELNAME=sentinel_cluster},


### PR DESCRIPTION
Hi,

I added FreeBSD-10.3 support and would be great if it could be part of the official redisio cookbook.
2 caveats: 
- installation from source is not supported because it would add a lot of extra dependencies for portsnap/portmaster and portsnap-downgrade
- setting ulimits is not supported because v0.1.2 of the ulimit cookbook is incompatible with FreeBSD (expects group 'root')