### PR TITLE
Systemd nolimit

### DIFF
--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -312,6 +312,15 @@ def configure
         })
         only_if { node['redisio']['job_control'] == 'upstart' }
       end
+      template "/usr/lib/systemd/system/redis@#{server_name}.service" do
+        cookbook 'redisio'
+        source    'redis@.service.erb'
+        variables({
+          :bin_path => bin_path,
+          :nofiles => descriptors 
+        })
+        only_if   { node['redisio']['job_control'] == 'systemd' }
+      end
     end
   end # servers each loop
 end

--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -316,8 +316,8 @@ def configure
         cookbook 'redisio'
         source 'redis@.service.erb'
         variables(
-          bin_path: bin_path,
-          nofiles: descriptors
+          :bin_path => bin_path,
+          :nofiles => descriptors
         )
         only_if { node['redisio']['job_control'] == 'systemd' }
       end

--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -314,12 +314,12 @@ def configure
       end
       template "/usr/lib/systemd/system/redis@#{server_name}.service" do
         cookbook 'redisio'
-        source    'redis@.service.erb'
-        variables({
-          :bin_path => bin_path,
-          :nofiles => descriptors 
-        })
-        only_if   { node['redisio']['job_control'] == 'systemd' }
+        source 'redis@.service.erb'
+        variables(
+          bin_path: bin_path,
+          nofiles: descriptors
+        )
+        only_if { node['redisio']['job_control'] == 'systemd' }
       end
     end
   end # servers each loop

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -35,8 +35,12 @@ redisio_configure "redis-servers" do
 end
 
 template '/usr/lib/systemd/system/redis@.service' do
+  cookbook 'redisio'
   source    'redis@.service.erb'
-  variables({ :bin_path => node['redisio']['bin_path'] })
+  variables({
+    :bin_path => node['redisio']['bin_path'],
+    :nofiles => node['redsio']['default']['maxclients'] + 32
+  })
   only_if   { node['redisio']['job_control'] == 'systemd' }
 end
 

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -34,16 +34,6 @@ redisio_configure "redis-servers" do
   base_piddir redis['base_piddir']
 end
 
-template '/usr/lib/systemd/system/redis@.service' do
-  cookbook 'redisio'
-  source    'redis@.service.erb'
-  variables({
-    :bin_path => node['redisio']['bin_path'],
-    :nofiles => node['redsio']['default']['maxclients'] + 32
-  })
-  only_if   { node['redisio']['job_control'] == 'systemd' }
-end
-
 # Create a service resource for each redis instance, named for the port it runs on.
 redis_instances.each do |current_server|
   server_name = current_server['name'] || current_server['port']

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -57,7 +57,7 @@ redis_instances.each do |current_server|
   when 'systemd'
     service "redis@#{server_name}" do
       provider Chef::Provider::Service::Systemd
-      supports :start => true, :stop => true, :restart => true, :status => true
+      supports start: true, stop: true, restart: true, status: true
     end
   else
     Chef::Log.error("Unknown job control type, no service resource created!")

--- a/recipes/enable.rb
+++ b/recipes/enable.rb
@@ -36,12 +36,5 @@ redis['servers'].each do |current_server|
   resource = resources(resource_name)
   resource.action Array(resource.action)
   resource.action << :start
-  if node['redisio']['job_control'] != 'systemd'
-    resource.action << :enable
-  else
-    link "/etc/systemd/system/multi-user.target.wants/redis@#{server_name}.service" do
-      to '/usr/lib/systemd/system/redis@.service'
-      notifies :run, 'execute[reload-systemd]', :immediately
-    end
-  end
+  resource.action << :enable
 end

--- a/templates/default/redis@.service.erb
+++ b/templates/default/redis@.service.erb
@@ -3,6 +3,7 @@ Description=Redis persistent key-value database
 After=network.target
 
 [Service]
+LimitNOFILE = <%= @nofiles %>
 ExecStart=<%= @bin_path %>/redis-server /etc/redis/%i.conf --daemonize no
 ExecStop=/usr/bin/redis-shutdown
 User=redis


### PR DESCRIPTION
Systemd does not respect the nofiles limits set outside the service script. This PR implements setting the nofiles accordingly. Had to move the system service script into the provider so that the proper descriptor values are used. This results in the need to create a separate service scrpt for each server instanes as maxclients could be different for each server instance.