### PR TITLE
Bug/package config

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,7 +10,11 @@ provisioner:
 platforms:
   - name: ubuntu-12.04
   - name: ubuntu-14.04
+  - name: ubuntu-16.04
   - name: debian-6.0.8
+  - name: debian-6.0.8
+  - name: debian-7.10
+  - name: debian-8.4
   - name: centos-6.6
     run_list:
       - recipe[yum-epel::default]

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'brian.bianco@gmail.com'
 license          'Apache 2.0'
 description      'Installs/Configures redis'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.4.2'
+version          '2.4.3'
 %w[ debian ubuntu centos redhat fedora scientific suse amazon].each do |os|
   supports os
 end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -23,9 +23,16 @@ if node['redisio']['package_install']
     action :install
   end
 
+case node['platform']
+when 'ubuntu','debian'
   service 'redis-server' do
     action [ :stop, :disable ]
   end
+when 'centos','redhat','scientific','amazon','suse','fedora'
+  service 'redis' do
+    action [ :stop, :disable ]
+  end
+end  
 
 else
   include_recipe 'redisio::_install_prereqs'

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -22,6 +22,11 @@ if node['redisio']['package_install']
     version node['redisio']['version'] if node['redisio']['version']
     action :install
   end
+
+  service 'redis-server' do
+    action [ :stop, :disable ]
+  end
+
 else
   include_recipe 'redisio::_install_prereqs'
   include_recipe 'build-essential::default'


### PR DESCRIPTION
When using the package method to install redis, it doesn't disables the default service.
When you create a new redis instance on the default port, it conflicts with the default installed version. 
I changed the script so when you install a package it will disable the default installed version.