### PR TITLE
Allow disabling safe_install in the install recipe

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -32,7 +32,7 @@ else
   redisio_install "redis-installation" do
     version redis['version'] if redis['version']
     download_url location
-    safe_install redis['safe_install'] if redis['safe_install']
+    safe_install redis['safe_install']
     install_dir redis['install_dir'] if redis['install_dir']
   end
 end


### PR DESCRIPTION
This prevented `false` from ever making it into the install resource, which defaults to `true`

The default is set here https://github.com/brianbianco/redisio/blob/master/resources/install.rb#L30