### PR TITLE
default packages_to_install to empty array 

### DIFF
--- a/recipes/_install_prereqs.rb
+++ b/recipes/_install_prereqs.rb
@@ -26,6 +26,8 @@ packages_to_install = case node['platform']
                         %w(
                           tar
                         )
+                      else
+                        %w()
                       end
 
 packages_to_install.each do |pkg|


### PR DESCRIPTION
On non-debian and non-rhel platforms this fixes nil exception when installing sentinel
