### PR TITLE
fix version detection with epoch version numbers from deb/ubuntu 

### DIFF
--- a/libraries/redisio.rb
+++ b/libraries/redisio.rb
@@ -44,7 +44,7 @@ module RedisioHelper
     version_array.flatten!
 
     {
-      major: version_array[0],
+      major: version_array[0].include?(':') ? version_array[0].split(':')[1] : version_array[0],
       minor: version_array[1],
       tiny: version_array[2],
       rc: version_array[3]


### PR DESCRIPTION
version could be like 2:3.0.6-rwky1~trusty and must be detected properly for including parts of configuration (vm-enable)
