### PR TITLE
Add support for bind in Sentinel

### DIFF
--- a/providers/sentinel.rb
+++ b/providers/sentinel.rb
@@ -152,6 +152,7 @@ def configure
           piddir:            piddir,
           job_control:       node['redisio']['job_control'],
           sentinel_port:     current['sentinel_port'],
+          sentinel_address:  current['sentinel_address'],
           loglevel:          current['loglevel'],
           logfile:           current['logfile'],
           syslogenabled:     current['syslogenabled'],

--- a/templates/default/sentinel.conf.erb
+++ b/templates/default/sentinel.conf.erb
@@ -39,6 +39,14 @@ port <%=@sentinel_port%>
 <%= "sentinel announce-ip #{@announce_ip}" unless @announce_ip.nil? %>
 <%= "sentinel announce-ip #{@announce_port}" unless @announce_port.nil? %>
 
+# If you want you can bind a single interface, if the bind option is not
+# specified all the interfaces will listen for incoming connections.
+#
+# bind 127.0.0.1
+<% unless @sentinel_address.nil? %>
+  <%= "bind #{@sentinel_address.respond_to?(:join) ? @sentinel_address.join(" ") : @sentinel_address }" %>
+<% end %>
+
 # sentinel monitor <master-name> <ip> <redis-port> <quorum>
 #
 # Tells Sentinel to monitor this slave, and to consider it in O_DOWN


### PR DESCRIPTION
Akin to the `bind` support in redis instance config, add support for
`bind` in Sentinel configuration.
