### PR TITLE
Check user existence with Etc, not ohai node attributes

### DIFF
--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -108,7 +108,14 @@ def configure
         shell current['shell']
         system current['systemuser']
         uid current['uid'] unless current['uid'].nil?
-        not_if { node['etc']['passwd'][current['user']] }
+
+        not_if do
+          begin
+            Etc.getpwnam current['user']
+          rescue ArgumentError
+            false
+          end
+        end
       end
       # Create the redis configuration directory
       directory current['configdir'] do

--- a/providers/sentinel.rb
+++ b/providers/sentinel.rb
@@ -47,7 +47,14 @@ def configure
         shell current['shell']
         system current['systemuser']
         uid current['uid'] unless current['uid'].nil?
-        not_if { node['etc']['passwd'][current['user']] }
+
+        not_if do
+          begin
+            Etc.getpwnam current['user']
+          rescue ArgumentError
+            false
+          end
+        end
       end
       # Create the redis configuration directory
       directory current['configdir'] do


### PR DESCRIPTION
`node['etc']['passwd']` is only refreshed by Ohai at the start of each Chef run so if the user is created earlier in the same run or if the Ohai plugin is disabled then this check blows up.

The check was going to be removed altogether according to #252 but I would not like this to happen. I would like to create a Redis instance under the same user that I have already set up for a different service. I imagine that's why the `not_if` was put there in the first place. This change deals with the main complaint of #252 (and also #296) but if you like, I could create an attribute such as `create_user` for this instead.