### PR TITLE
Allow /etc/init start after sigterm from system or user

### DIFF
--- a/templates/default/redis.init.erb
+++ b/templates/default/redis.init.erb
@@ -58,6 +58,14 @@ case "$1" in
         if [ -f $PIDFILE ]
         then
                 echo "$PIDFILE exists, process is already running or crashed"
+		PIDNUM=`cat $PIDFILE`
+		PROCESS_RUNNING=`ps --no-headers -q $PIDNUM | wc -l`
+		if [ ! $PROCESS_RUNNING -eq 1 ]
+		then
+			echo "The PID doesn't exists, restarting it."
+			rm $PIDFILE
+			eval $EXEC
+		fi
         else
                 echo "Starting Redis server..."
                 eval $EXEC


### PR DESCRIPTION
I made a modification to allow redis init to start even if the app was crashed.

Current behaviour: System or user sigkill the app ( -9 ), then the init was only trusting if the pid exist or not, but because sigkill doesn't notify the process to be killed, the pid will remain, so the init will not allow you to start unless you remove the PID.

This is very useful in case the system kills REDIS by excess of memory.