### PR TITLE
rename_commands should be checked for nil before empty

### DIFF
--- a/templates/default/redis.conf.erb
+++ b/templates/default/redis.conf.erb
@@ -371,7 +371,7 @@ slave-priority <%= @slavepriority %>
 # rename-command CONFIG ""
 <% if !@rename_commands.nil? %>
   <% @rename_commands.each do |k, v| %>
-    <% v = '""' if v.empty? || v.nil? %>
+    <% v = '""' if v.nil? || v.empty? %>
     <%= "rename-command #{k} #{v}" %>
   <% end %>
 <% end %>


### PR DESCRIPTION
…d .empty? for NilClass]

Switching the order of the test from:
```ruby 
v.empty? || v.nil? 
``` 
to this:
```ruby
v.nil? || v.empty?
``` 

Will fix the problem