### PR TITLE
Add min-slaves redis options

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -158,7 +158,9 @@ default['redisio']['default_settings'] = {
   'includes'                 => nil,
   'data_bag_name'            => nil,
   'data_bag_item'            => nil,
-  'data_bag_key'             => nil
+  'data_bag_key'             => nil,
+  'minslavestowrite'         => nil,
+  'minslavesmaxlag'          => nil
 }
 
 # The default for this is set inside of the "install" recipe. This is due to the way deep merge handles arrays

--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -270,7 +270,9 @@ def configure
           clusterenabled:             current['clusterenabled'],
           clusterconfigfile:          current['clusterconfigfile'],
           clusternodetimeout:         current['clusternodetimeout'],
-          includes:                   current['includes']
+          includes:                   current['includes'],
+          minslavestowrite:           current['minslavestowrite'],
+          minslavesmaxlag:            current['minslavesmaxlag']
         )
         not_if { ::File.exist?("#{current['configdir']}/#{server_name}.conf.breadcrumb") }
       end

--- a/templates/default/redis.conf.erb
+++ b/templates/default/redis.conf.erb
@@ -338,6 +338,7 @@ repl-backlog-ttl <%= @replbacklogttl %>
 # By default the priority is 100.
 slave-priority <%= @slavepriority %>
 
+<% if @version[:major].to_i >= 3 %>
 # It is possible for a master to stop accepting writes if there are less than
 # N slaves connected, having a lag less or equal than M seconds.
 #
@@ -361,7 +362,9 @@ slave-priority <%= @slavepriority %>
 # min-slaves-max-lag is set to 10.
 <%= "min-slaves-to-write #{@minslavestowrite}" unless @minslavestowrite.nil? %>
 <%= "min-slaves-max-lag #{@minslavesmaxlag}" unless @minslavesmaxlag.nil? %>
+<% end %>
 
+<% if @version[:major].to_i >= 4 %>
 # A Redis master is able to list the address and port of the attached
 # slaves in different ways. For example the "INFO replication" section
 # offers this information, which is used, among other tools, by
@@ -390,6 +393,7 @@ slave-priority <%= @slavepriority %>
 #
 # slave-announce-ip 5.5.5.5
 # slave-announce-port 1234
+<% end %>
 
 ################################## SECURITY ###################################
 

--- a/templates/default/redis.conf.erb
+++ b/templates/default/redis.conf.erb
@@ -338,6 +338,59 @@ repl-backlog-ttl <%= @replbacklogttl %>
 # By default the priority is 100.
 slave-priority <%= @slavepriority %>
 
+# It is possible for a master to stop accepting writes if there are less than
+# N slaves connected, having a lag less or equal than M seconds.
+#
+# The N slaves need to be in "online" state.
+#
+# The lag in seconds, that must be <= the specified value, is calculated from
+# the last ping received from the slave, that is usually sent every second.
+#
+# This option does not GUARANTEE that N replicas will accept the write, but
+# will limit the window of exposure for lost writes in case not enough slaves
+# are available, to the specified number of seconds.
+#
+# For example to require at least 3 slaves with a lag <= 10 seconds use:
+#
+# min-slaves-to-write 3
+# min-slaves-max-lag 10
+#
+# Setting one or the other to 0 disables the feature.
+#
+# By default min-slaves-to-write is set to 0 (feature disabled) and
+# min-slaves-max-lag is set to 10.
+<%= "min-slaves-to-write #{@minslavestowrite}" unless @minslavestowrite.nil? %>
+<%= "min-slaves-max-lag #{@minslavesmaxlag}" unless @minslavesmaxlag.nil? %>
+
+# A Redis master is able to list the address and port of the attached
+# slaves in different ways. For example the "INFO replication" section
+# offers this information, which is used, among other tools, by
+# Redis Sentinel in order to discover slave instances.
+# Another place where this info is available is in the output of the
+# "ROLE" command of a masteer.
+#
+# The listed IP and address normally reported by a slave is obtained
+# in the following way:
+#
+#   IP: The address is auto detected by checking the peer address
+#   of the socket used by the slave to connect with the master.
+#
+#   Port: The port is communicated by the slave during the replication
+#   handshake, and is normally the port that the slave is using to
+#   list for connections.
+#
+# However when port forwarding or Network Address Translation (NAT) is
+# used, the slave may be actually reachable via different IP and port
+# pairs. The following two options can be used by a slave in order to
+# report to its master a specific set of IP and port, so that both INFO
+# and ROLE will report those values.
+#
+# There is no need to use both the options if you need to override just
+# the port or the IP address.
+#
+# slave-announce-ip 5.5.5.5
+# slave-announce-port 1234
+
 ################################## SECURITY ###################################
 
 # Require clients to issue AUTH <PASSWORD> before processing any other


### PR DESCRIPTION
This is useful when using sentinel and redis together with several slaves

- min-slaves-to-write (config attribute `minslavestowrite`)
- min-slaves-max-lag (config attribute `minslavesmaxlag`)