### PR TITLE
Change default version to the 'battle tested' stable version 3.2.11

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -64,7 +64,7 @@ default['redisio']['version'] = if node['redisio']['package_install']
                                   nil
                                 else
                                   # force version for tarball
-                                  '2.8.20'
+                                  '3.2.11'
                                 end
 
 # Custom installation directory


### PR DESCRIPTION
Version 2.8.20 is a very old version. The current stable is 4.0.2. However, a good compromise is the "battle tested" (Redis' words) Stable 3.2.11. This tiny PR makes that change.